### PR TITLE
RTS audio recommendation feature

### DIFF
--- a/docs/RECOMMENDATION.md
+++ b/docs/RECOMMENDATION.md
@@ -7,7 +7,7 @@ Playfff is the middleware to deliver recommendations for Play SRG mobile applica
 
 ## Compatibility
 
-Play Android and Play iOS (2.8.3-272 and more) applications currently use it. 
+Since July 2018, Play Android (2.0.207 and more) and Play iOS (2.8.3-272 and more) applications currently use it.
 
 ## Recommendation type
 

--- a/docs/RECOMMENDATION.md
+++ b/docs/RECOMMENDATION.md
@@ -11,22 +11,21 @@ Play Android and Play iOS (2.8.3-272 and more) applications currently use it.
 
 ## Recommendation type
 
-### Recommendation list for a media
+### Media ecommendation list for a media
 
-The API doesn't not support paginations, mobile applications don't implement also pagination. The recommendation list must have at least 49 items, the 50th is the requested media itself.
+The API doesn't not support paginations, so mobile applications didn't implement pagination. The media recommendation list must have at least 49 items, the 50th is the requested media itself.
 
 #### RTS `urn.contains(":rts:")`
 
 - For videos `urn.contains(":video:")`, ask Peach recommendation `continuous_playback_mobile`.
 - For audios `urn.contains(":audio:")`:
 	- Get `IL-Media`. It returns an empty list if it's a `LIVESTREAM` or a `SCHEDULED_LIVESTREAM`.
-	- Get `IL-EpisodeComposition`, last 100 episodes.
+	- Get `IL-EpisodeComposition`, last 100 episodes. Sort in date ascending order.
 	- Determine if the media is a full length or a clip. Separate full length list and the clip list.
-	- Get the media position in the related lists.
+	- Get the media position in the related lists. Split oldests and newests.
 	- Recommendation list:
-		- Newest media from oldest to the last published. Then:
-		- if `nextUrl` (more than 100 episodes), old ones from newest to oldest to newer.
-		- else, from the older one to newer.
+		- Newest medias in date ascending order. Then:
+		- if `nextUrl` exists (show has more than 100 episodes), oldest medias in date descending order.		- else (show has less than 100 episodes), oldest medias in date ascending order.
 
 #### Other BUs
 

--- a/docs/RECOMMENDATION.md
+++ b/docs/RECOMMENDATION.md
@@ -1,0 +1,37 @@
+Playfff - Recommendation
+=============
+
+## About
+
+Playfff is the middleware to deliver recommendations for Play SRG mobile applications.
+
+## Compatibility
+
+Play Android and Play iOS (2.8.3-272 and more) applications currently use it. 
+
+## Recommendation type
+
+### Recommendation list for a media
+
+The API doesn't not support paginations, mobile applications don't implement also pagination. The recommendation list must have at least 49 items, the 50th is the requested media itself.
+
+#### RTS `urn.contains(":rts:")`
+
+- For videos `urn.contains(":video:")`, ask Peach recommendation `continuous_playback_mobile`.
+- For audios `urn.contains(":audio:")`:
+	- Get `IL-Media`. It returns an empty list if it's a `LIVESTREAM` or a `SCHEDULED_LIVESTREAM`.
+	- Get `IL-EpisodeComposition`, last 100 episodes.
+	- Determine if the media is a full length or a clip. Separate full length list and the clip list.
+	- Get the media position in the related lists.
+	- Recommendation list:
+		- Newest media from oldest to the last published. Then:
+		- if `nextUrl` (more than 100 episodes), old ones from newest to oldest to newer.
+		- else, from the older one to newer.
+
+#### Other BUs
+
+- No recommendation provided. It returns an empty list.
+ 
+## License
+
+To be defined.

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,13 @@
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 
+	<repositories>
+		<repository>
+			<id>SRF repository</id>
+			<url>http://maven.admin.srf.ch</url>
+		</repository>
+	</repositories>
+
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -90,6 +97,17 @@
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>ch.srf.integrationlayer</groupId>
+			<artifactId>integrationlayer-domain-objects</artifactId>
+			<version>1.20.272</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>27.0.1-jre</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,6 +3,13 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
+	<repositories>
+		<repository>
+			<id>SRF repository</id>
+			<url>http://maven.admin.srf.ch</url>
+		</repository>
+	</repositories>
+
 	<groupId>com.example</groupId>
 	<artifactId>pfff</artifactId>
 	<version>7</version>
@@ -17,13 +24,6 @@
 		<version>1.5.9.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
-
-	<repositories>
-		<repository>
-			<id>SRF repository</id>
-			<url>http://maven.admin.srf.ch</url>
-		</repository>
-	</repositories>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,12 @@
 			<artifactId>guava</artifactId>
 			<version>27.0.1-jre</version>
 		</dependency>
+
+		<dependency>
+			<groupId>com.alibaba</groupId>
+			<artifactId>fastjson</artifactId>
+			<version>1.2.55</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -109,12 +109,6 @@
 			<artifactId>guava</artifactId>
 			<version>27.0.1-jre</version>
 		</dependency>
-
-		<dependency>
-			<groupId>com.alibaba</groupId>
-			<artifactId>fastjson</artifactId>
-			<version>1.2.55</version>
-		</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,8 @@
 
 	<repositories>
 		<repository>
-			<id>SRF repository</id>
-			<url>http://maven.admin.srf.ch</url>
+			<id>Pfff repository</id>
+			<url>https://raw.github.com/SRGSSR/pfff/mvn-repo/</url>
 		</repository>
 	</repositories>
 

--- a/src/main/java/com/example/pfff/model/Environment.java
+++ b/src/main/java/com/example/pfff/model/Environment.java
@@ -1,0 +1,37 @@
+package com.example.pfff.model;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Copyright (c) SRG SSR. All rights reserved.
+ * <p>
+ * License information is available from the LICENSE file.
+ */
+public enum Environment {
+    PROD("il.srgssr.ch"),
+    STAGE("il-stage.srgssr.ch"),
+    TEST("il-test.srgssr.ch"),
+    MMF("play-mmf.herokuapp.com");
+
+    Environment(String url) {
+        this.name = name().toLowerCase();
+        this.baseUrl = url;
+    }
+
+    private String name;
+    private String baseUrl;
+
+    public static Environment fromValue(String v) {
+        return valueOf(v.toUpperCase());
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    @JsonValue
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/src/main/java/com/example/pfff/model/RecommendedList.java
+++ b/src/main/java/com/example/pfff/model/RecommendedList.java
@@ -27,7 +27,7 @@ public class RecommendedList {
         } else {
             this.recommendationId = recommendationId;
         }
-        this.urns = urns;
+        this.urns = (urns != null) ? urns : new ArrayList<String>();
     }
 
     public RecommendedList() {

--- a/src/main/java/com/example/pfff/service/IntegrationLayerRequest.java
+++ b/src/main/java/com/example/pfff/service/IntegrationLayerRequest.java
@@ -1,0 +1,74 @@
+package com.example.pfff.service;
+
+import ch.srg.il.domain.v2_0.EpisodeComposition;
+import ch.srg.il.domain.v2_0.Media;
+import ch.srg.il.domain.v2_0.Show;
+import ch.srg.jaxb.SrgUnmarshaller;
+import com.example.pfff.model.Environment;
+import org.eclipse.persistence.oxm.MediaType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Copyright (c) SRG SSR. All rights reserved.
+ * <p>
+ * License information is available from the LICENSE file.
+ */
+@Service
+public class IntegrationLayerRequest {
+    private static final Logger logger = LoggerFactory.getLogger(IntegrationLayerRequest.class);
+    public static final int PORT = 80;
+    private final RestTemplate restTemplate;
+
+    public IntegrationLayerRequest(RestTemplateBuilder restTemplateBuilder) {
+        restTemplate = restTemplateBuilder.build();
+    }
+
+    public EpisodeComposition getEpisodeCompositionLatestByShow(String showURN, ZonedDateTime maxPublishedDate, Environment environment) {
+        String path = "/integrationlayer/2.0/episodeComposition/latestByShow/byUrn/" + showURN + ".json";
+        String query = (maxPublishedDate != null) ? "maxPublishedDate=" + DateTimeFormatter.ofPattern("yyyy-MM-dd").format(maxPublishedDate) : null;
+        try {
+            URI uri = new URI("http", null, environment.getBaseUrl(), PORT, path, query, null);
+            ResponseEntity<String> responseEntity = restTemplate.getForEntity(uri, String.class);
+            SrgUnmarshaller unmarshaller = new SrgUnmarshaller();
+            return unmarshaller.unmarshal(responseEntity.getBody(), MediaType.APPLICATION_JSON, EpisodeComposition.class);
+        } catch (Exception e) {
+            logger.warn("http://{}{} : {}", environment.getBaseUrl(), path, e.getMessage());
+            return null;
+        }
+    }
+
+    public Media getMedia(String mediaURN, Environment environment) {
+        String path = "/integrationlayer/2.0/media/byUrn/" + mediaURN + ".json";
+        try {
+            URI uri = new URI("http", null, environment.getBaseUrl(), PORT, path, null, null);
+            ResponseEntity<String> responseEntity = restTemplate.getForEntity(uri, String.class);
+            SrgUnmarshaller unmarshaller = new SrgUnmarshaller();
+            return unmarshaller.unmarshal(responseEntity.getBody(), MediaType.APPLICATION_JSON, Media.class);
+        } catch (Exception e) {
+            logger.warn("http://{}{} : {}", environment.getBaseUrl(), path, e.getMessage());
+            return null;
+        }
+    }
+
+    public Show getShow(String showURN, Environment environment) {
+        String path = "/integrationlayer/2.0/show/byUrn/" + showURN + ".json";
+        try {
+            URI uri = new URI("http", null, environment.getBaseUrl(), PORT, path, null, null);
+            ResponseEntity<String> responseEntity = restTemplate.getForEntity(uri, String.class);
+            SrgUnmarshaller unmarshaller = new SrgUnmarshaller();
+            return unmarshaller.unmarshal(responseEntity.getBody(), MediaType.APPLICATION_JSON, Show.class);
+        } catch (Exception e) {
+            logger.warn("http://{}{} : {}", environment.getBaseUrl(), path, e.getMessage());
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/example/pfff/service/IntegrationLayerRequest.java
+++ b/src/main/java/com/example/pfff/service/IntegrationLayerRequest.java
@@ -27,7 +27,8 @@ import java.time.format.DateTimeFormatter;
 public class IntegrationLayerRequest {
     private static final Logger logger = LoggerFactory.getLogger(IntegrationLayerRequest.class);
     public static final int PORT = 80;
-    private final RestTemplate restTemplate;
+    
+    private RestTemplate restTemplate;
 
     public IntegrationLayerRequest(RestTemplateBuilder restTemplateBuilder) {
         restTemplate = restTemplateBuilder.build();
@@ -79,5 +80,10 @@ public class IntegrationLayerRequest {
     @VisibleForTesting
     public RestTemplate getRestTemplate() {
         return restTemplate;
+    }
+
+    @VisibleForTesting
+    public void setRestTemplate(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
     }
 }

--- a/src/main/java/com/example/pfff/service/IntegrationLayerRequest.java
+++ b/src/main/java/com/example/pfff/service/IntegrationLayerRequest.java
@@ -5,6 +5,7 @@ import ch.srg.il.domain.v2_0.Media;
 import ch.srg.il.domain.v2_0.Show;
 import ch.srg.jaxb.SrgUnmarshaller;
 import com.example.pfff.model.Environment;
+import org.assertj.core.util.VisibleForTesting;
 import org.eclipse.persistence.oxm.MediaType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,5 +74,10 @@ public class IntegrationLayerRequest {
             logger.warn("http://{}{} : {}", environment.getBaseUrl(), path, e.getMessage());
             return null;
         }
+    }
+
+    @VisibleForTesting
+    public RestTemplate getRestTemplate() {
+        return restTemplate;
     }
 }

--- a/src/main/java/com/example/pfff/service/IntegrationLayerRequest.java
+++ b/src/main/java/com/example/pfff/service/IntegrationLayerRequest.java
@@ -32,9 +32,12 @@ public class IntegrationLayerRequest {
         restTemplate = restTemplateBuilder.build();
     }
 
-    public EpisodeComposition getEpisodeCompositionLatestByShow(String showURN, ZonedDateTime maxPublishedDate, Environment environment) {
+    public EpisodeComposition getEpisodeCompositionLatestByShow(String showURN, ZonedDateTime maxPublishedDate, int pageSize, Environment environment) {
         String path = "/integrationlayer/2.0/episodeComposition/latestByShow/byUrn/" + showURN + ".json";
-        String query = (maxPublishedDate != null) ? "maxPublishedDate=" + DateTimeFormatter.ofPattern("yyyy-MM-dd").format(maxPublishedDate) : null;
+        String query = "pageSize=" + pageSize;
+        if (maxPublishedDate != null) {
+            query += "&maxPublishedDate=" + DateTimeFormatter.ofPattern("yyyy-MM-dd").format(maxPublishedDate);
+        }
         try {
             URI uri = new URI("http", null, environment.getBaseUrl(), PORT, path, query, null);
             ResponseEntity<String> responseEntity = restTemplate.getForEntity(uri, String.class);

--- a/src/main/java/com/example/pfff/service/RecommendationService.java
+++ b/src/main/java/com/example/pfff/service/RecommendationService.java
@@ -85,9 +85,9 @@ public class RecommendationService {
                     urns = isFullLengthUrns ? fullLengthUrns : clipUrns;
                 }
 
-                // First: newest urns from oldest to the last published. Then:
-                // - if next url (pageSize=100), old ones from newest to oldest to newer.
-                // - else, from the older one to newer.
+                // First: newest medias in date ascending order. Then:
+                // - if `nextUrl` exists (show has more than 100 episodes), oldest medias in date descending order.
+                // - else (show has less than 100 episodes), oldest medias in date ascending order.
                 if (index > -1 && index < urns.size() - 1) {
                     recommendationResult = new ArrayList<>(urns.subList(index + 1, urns.size()));
                     urns.removeAll(recommendationResult);

--- a/src/main/java/com/example/pfff/service/RecommendationService.java
+++ b/src/main/java/com/example/pfff/service/RecommendationService.java
@@ -54,7 +54,7 @@ public class RecommendationService {
                     return new RecommendedList();
                 }
 
-                EpisodeComposition episodeComposition = integrationLayerRequest.getEpisodeCompositionLatestByShow(media.getShow().getUrn(), null, Environment.PROD);
+                EpisodeComposition episodeComposition = integrationLayerRequest.getEpisodeCompositionLatestByShow(media.getShow().getUrn(), null, 50, Environment.PROD);
                 if (episodeComposition == null) {
                     new RecommendedList();
                 }
@@ -68,28 +68,38 @@ public class RecommendationService {
                 List<String> recommendationResult = null;
 
                 if (fullLengthUrns.contains(urn)) {
+                    // New urns first from newest to oldest, then old ones from newest to oldest.
                     isFullLengthUrns = true;
                     int index = fullLengthUrns.lastIndexOf(urn);
                     if (index < fullLengthUrns.size() - 1) {
-                        recommendationResult = fullLengthUrns.subList(index + 1, fullLengthUrns.size());
+                        recommendationResult = new ArrayList<>(fullLengthUrns.subList(index + 1, fullLengthUrns.size()));
+                        fullLengthUrns.removeAll(recommendationResult);
+                        fullLengthUrns.remove(urn);
+                        recommendationResult.addAll(Lists.reverse(fullLengthUrns));
                     }
                     else {
-                        recommendationResult = new ArrayList<>();
+                        // Newest to oldest.
+                        recommendationResult = Lists.reverse(fullLengthUrns);
                     }
                 }
                 else if (clipUrns.contains(urn)) {
+                    // New urns first from newest to oldest, then old ones from newest to oldest.
                     isFullLengthUrns = false;
                     int index = clipUrns.lastIndexOf(urn);
                     if (index < clipUrns.size() - 1) {
-                        recommendationResult = clipUrns.subList(index + 1, clipUrns.size());
+                        recommendationResult = new ArrayList<>(clipUrns.subList(index + 1, clipUrns.size()));
+                        clipUrns.removeAll(recommendationResult);
+                        clipUrns.remove(urn);
+                        recommendationResult.addAll(Lists.reverse(clipUrns));
                     }
                     else {
-                        recommendationResult = new ArrayList<>();
+                        // Newest to oldest.
+                        recommendationResult = Lists.reverse(clipUrns);
                     }
                 }
                 else {
                     isFullLengthUrns = media.getType() != CLIP;
-                    recommendationResult = isFullLengthUrns ? fullLengthUrns : clipUrns;
+                    recommendationResult = isFullLengthUrns ? Lists.reverse(fullLengthUrns) : Lists.reverse(clipUrns);
                 }
 
                 String host = "playfff.srgssr.ch";

--- a/src/main/java/com/example/pfff/service/RecommendationService.java
+++ b/src/main/java/com/example/pfff/service/RecommendationService.java
@@ -45,7 +45,7 @@ public class RecommendationService {
 
                 EpisodeComposition episodeComposition = integrationLayerRequest.getEpisodeCompositionLatestByShow(media.getShow().getUrn(), null, 100, Environment.PROD);
                 if (episodeComposition == null) {
-                    new RecommendedList();
+                    return new RecommendedList();
                 }
 
                 List<EpisodeWithMedias> episodes = Lists.reverse(episodeComposition.getList());

--- a/src/main/java/com/example/pfff/service/RecommendationService.java
+++ b/src/main/java/com/example/pfff/service/RecommendationService.java
@@ -88,11 +88,11 @@ public class RecommendationService {
         if (index > -1 && index < urns.size() - 1) {
             recommendationResult = new ArrayList<>(urns.subList(index + 1, urns.size()));
             urns.removeAll(recommendationResult);
-            urns.remove(urn);
         } else {
             // Latest urn or not found urn
             recommendationResult = new ArrayList<>();
         }
+        urns.remove(urn);
 
         if (episodeComposition.getNext() != null) {
             recommendationResult.addAll(Lists.reverse(urns));

--- a/src/main/java/com/example/pfff/service/RecommendationService.java
+++ b/src/main/java/com/example/pfff/service/RecommendationService.java
@@ -48,7 +48,7 @@ public class RecommendationService {
                 RecommendationResult recommendationResult = restTemplate.exchange(url.toUriString(), HttpMethod.GET, null, RecommendationResult.class).getBody();
                 return new RecommendedList(url.getHost(), recommendationResult.getRecommendationId(), recommendationResult.getUrns());
             }
-            else {
+            else if (urn.contains(":audio:")) {
                 Media media = integrationLayerRequest.getMedia(urn, Environment.PROD);
                 if (media == null || media.getType() == LIVESTREAM || media.getType() == SCHEDULED_LIVESTREAM || media.getShow() == null) {
                     return new RecommendedList();
@@ -113,6 +113,9 @@ public class RecommendationService {
                 }
 
                 return new RecommendedList(host, recommendationId, recommendationResult);
+            }
+            else {
+                return new RecommendedList();
             }
         }
         else {

--- a/src/main/java/com/example/pfff/service/RecommendationService.java
+++ b/src/main/java/com/example/pfff/service/RecommendationService.java
@@ -37,8 +37,7 @@ public class RecommendationService {
         if (urn.contains(":rts:")) {
             if (urn.contains(":video:")) {
                 return videoRecommendedList(purpose, urn, standalone);
-            }
-            else if (urn.contains(":audio:")) {
+            } else if (urn.contains(":audio:")) {
                 Media media = integrationLayerRequest.getMedia(urn, Environment.PROD);
                 if (media == null || media.getType() == LIVESTREAM || media.getType() == SCHEDULED_LIVESTREAM || media.getShow() == null) {
                     return new RecommendedList();
@@ -64,13 +63,11 @@ public class RecommendationService {
                     isFullLengthUrns = true;
                     index = fullLengthUrns.lastIndexOf(urn);
                     urns = fullLengthUrns;
-                }
-                else if (clipUrns.contains(urn)) {
+                } else if (clipUrns.contains(urn)) {
                     isFullLengthUrns = false;
                     index = clipUrns.lastIndexOf(urn);
                     urns = clipUrns;
-                }
-                else {
+                } else {
                     isFullLengthUrns = media.getType() != CLIP;
                     urns = isFullLengthUrns ? fullLengthUrns : clipUrns;
                 }
@@ -82,16 +79,14 @@ public class RecommendationService {
                     recommendationResult = new ArrayList<>(urns.subList(index + 1, urns.size()));
                     urns.removeAll(recommendationResult);
                     urns.remove(urn);
-                }
-                else {
+                } else {
                     // Latest urn or not found urn
                     recommendationResult = new ArrayList<>();
                 }
 
                 if (episodeComposition.getNext() != null) {
                     recommendationResult.addAll(Lists.reverse(urns));
-                }
-                else {
+                } else {
                     recommendationResult.addAll(urns);
                 }
 
@@ -103,12 +98,10 @@ public class RecommendationService {
                 }
 
                 return new RecommendedList(host, recommendationId, recommendationResult);
-            }
-            else {
+            } else {
                 return new RecommendedList();
             }
-        }
-        else {
+        } else {
             return new RecommendedList();
         }
     }

--- a/src/main/java/com/example/pfff/service/RecommendationService.java
+++ b/src/main/java/com/example/pfff/service/RecommendationService.java
@@ -39,7 +39,7 @@ public class RecommendationService {
                 UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.newInstance().scheme("http").host("peach.ebu.io").path("api/v1/chrts/continuous_playback_mobile");
                 uriComponentsBuilder.queryParam("urn", urn);
                 uriComponentsBuilder.queryParam("purpose", purpose);
-                uriComponentsBuilder.queryParam("pageSize", 50);
+                uriComponentsBuilder.queryParam("pageSize", 49);
                 uriComponentsBuilder.queryParam("standalone", standalone);
                 UriComponents url = uriComponentsBuilder.build();
 
@@ -105,8 +105,8 @@ public class RecommendationService {
                 String host = "playfff.srgssr.ch";
                 String recommendationId = "EpisodeComposition/LatestByShow/" + (isFullLengthUrns ? "FullLength" : "Clip");
 
-                if (recommendationResult.size() > 50) {
-                    recommendationResult = recommendationResult.subList(0, 51);
+                if (recommendationResult.size() > 49) {
+                    recommendationResult = recommendationResult.subList(0, 49);
                 }
 
                 return new RecommendedList(host, recommendationId, recommendationResult);

--- a/src/main/java/com/example/pfff/service/RecommendationService.java
+++ b/src/main/java/com/example/pfff/service/RecommendationService.java
@@ -38,72 +38,76 @@ public class RecommendationService {
             if (urn.contains(":video:")) {
                 return rtsVideoRecommendedList(purpose, urn, standalone);
             } else if (urn.contains(":audio:")) {
-                Media media = integrationLayerRequest.getMedia(urn, Environment.PROD);
-                if (media == null || media.getType() == LIVESTREAM || media.getType() == SCHEDULED_LIVESTREAM || media.getShow() == null) {
-                    return new RecommendedList();
-                }
-
-                EpisodeComposition episodeComposition = integrationLayerRequest.getEpisodeCompositionLatestByShow(media.getShow().getUrn(), null, 100, Environment.PROD);
-                if (episodeComposition == null) {
-                    return new RecommendedList();
-                }
-
-                List<EpisodeWithMedias> episodes = Lists.reverse(episodeComposition.getList());
-                List<String> fullLengthUrns = episodes.stream().map(EpisodeWithMedias::getFullLengthUrn).collect(Collectors.toList());
-                List<String> clipUrns = episodes.stream().flatMap(e -> e.getMediaList().stream().filter(m -> m.getMediaType() == MediaType.AUDIO)).map(Media::getUrn).collect(Collectors.toList());
-                clipUrns.removeAll(fullLengthUrns);
-
-                Boolean isFullLengthUrns = false;
-                List<String> recommendationResult = null;
-
-                List<String> urns = null;
-                int index = -1;
-
-                if (fullLengthUrns.contains(urn)) {
-                    isFullLengthUrns = true;
-                    index = fullLengthUrns.lastIndexOf(urn);
-                    urns = fullLengthUrns;
-                } else if (clipUrns.contains(urn)) {
-                    isFullLengthUrns = false;
-                    index = clipUrns.lastIndexOf(urn);
-                    urns = clipUrns;
-                } else {
-                    isFullLengthUrns = media.getType() != CLIP;
-                    urns = isFullLengthUrns ? fullLengthUrns : clipUrns;
-                }
-
-                // First: newest medias in date ascending order. Then:
-                // - if `nextUrl` exists (show has more than 100 episodes), oldest medias in date descending order.
-                // - else (show has less than 100 episodes), oldest medias in date ascending order.
-                if (index > -1 && index < urns.size() - 1) {
-                    recommendationResult = new ArrayList<>(urns.subList(index + 1, urns.size()));
-                    urns.removeAll(recommendationResult);
-                    urns.remove(urn);
-                } else {
-                    // Latest urn or not found urn
-                    recommendationResult = new ArrayList<>();
-                }
-
-                if (episodeComposition.getNext() != null) {
-                    recommendationResult.addAll(Lists.reverse(urns));
-                } else {
-                    recommendationResult.addAll(urns);
-                }
-
-                String host = "playfff.srgssr.ch";
-                String recommendationId = "EpisodeComposition/LatestByShow/" + (isFullLengthUrns ? "FullLength" : "Clip");
-
-                if (recommendationResult.size() > 49) {
-                    recommendationResult = recommendationResult.subList(0, 49);
-                }
-
-                return new RecommendedList(host, recommendationId, recommendationResult);
+                return rtsAudioRecommendedList(urn);
             } else {
                 return new RecommendedList();
             }
         } else {
             return new RecommendedList();
         }
+    }
+
+    private RecommendedList rtsAudioRecommendedList(String urn) {
+        Media media = integrationLayerRequest.getMedia(urn, Environment.PROD);
+        if (media == null || media.getType() == LIVESTREAM || media.getType() == SCHEDULED_LIVESTREAM || media.getShow() == null) {
+            return new RecommendedList();
+        }
+
+        EpisodeComposition episodeComposition = integrationLayerRequest.getEpisodeCompositionLatestByShow(media.getShow().getUrn(), null, 100, Environment.PROD);
+        if (episodeComposition == null) {
+            return new RecommendedList();
+        }
+
+        List<EpisodeWithMedias> episodes = Lists.reverse(episodeComposition.getList());
+        List<String> fullLengthUrns = episodes.stream().map(EpisodeWithMedias::getFullLengthUrn).collect(Collectors.toList());
+        List<String> clipUrns = episodes.stream().flatMap(e -> e.getMediaList().stream().filter(m -> m.getMediaType() == MediaType.AUDIO)).map(Media::getUrn).collect(Collectors.toList());
+        clipUrns.removeAll(fullLengthUrns);
+
+        Boolean isFullLengthUrns = false;
+        List<String> recommendationResult = null;
+
+        List<String> urns = null;
+        int index = -1;
+
+        if (fullLengthUrns.contains(urn)) {
+            isFullLengthUrns = true;
+            index = fullLengthUrns.lastIndexOf(urn);
+            urns = fullLengthUrns;
+        } else if (clipUrns.contains(urn)) {
+            isFullLengthUrns = false;
+            index = clipUrns.lastIndexOf(urn);
+            urns = clipUrns;
+        } else {
+            isFullLengthUrns = media.getType() != CLIP;
+            urns = isFullLengthUrns ? fullLengthUrns : clipUrns;
+        }
+
+        // First: newest medias in date ascending order. Then:
+        // - if `nextUrl` exists (show has more than 100 episodes), oldest medias in date descending order.
+        // - else (show has less than 100 episodes), oldest medias in date ascending order.
+        if (index > -1 && index < urns.size() - 1) {
+            recommendationResult = new ArrayList<>(urns.subList(index + 1, urns.size()));
+            urns.removeAll(recommendationResult);
+            urns.remove(urn);
+        } else {
+            // Latest urn or not found urn
+            recommendationResult = new ArrayList<>();
+        }
+
+        if (episodeComposition.getNext() != null) {
+            recommendationResult.addAll(Lists.reverse(urns));
+        } else {
+            recommendationResult.addAll(urns);
+        }
+
+        String host = "playfff.srgssr.ch";
+        String recommendationId = "EpisodeComposition/LatestByShow/" + (isFullLengthUrns ? "FullLength" : "Clip");
+
+        if (recommendationResult.size() > 49) {
+            recommendationResult = recommendationResult.subList(0, 49);
+        }
+
+        return new RecommendedList(host, recommendationId, recommendationResult);
     }
 
     private RecommendedList rtsVideoRecommendedList(String purpose, String urn, boolean standalone) {

--- a/src/main/java/com/example/pfff/service/RecommendationService.java
+++ b/src/main/java/com/example/pfff/service/RecommendationService.java
@@ -1,7 +1,14 @@
 package com.example.pfff.service;
 
+import ch.srg.il.domain.v2_0.EpisodeComposition;
+import ch.srg.il.domain.v2_0.EpisodeWithMedias;
+import ch.srg.il.domain.v2_0.Media;
+import ch.srg.il.domain.v2_0.MediaType;
+import com.example.pfff.model.Environment;
 import com.example.pfff.model.RecommendedList;
 import com.example.pfff.model.peach.RecommendationResult;
+import com.google.common.collect.Lists;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
@@ -10,9 +17,15 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+
+import static ch.srg.il.domain.v2_0.Type.*;
 
 @Service
 public class RecommendationService {
+
+    @Autowired
+    private IntegrationLayerRequest integrationLayerRequest;
 
     private RestTemplate restTemplate;
 
@@ -22,17 +35,72 @@ public class RecommendationService {
 
     public RecommendedList getRecommendedUrns(String purpose, String urn, boolean standalone) {
         if (urn.contains(":rts:")) {
-            UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.newInstance().scheme("http").host("peach.ebu.io").path("api/v1/chrts/continuous_playback_mobile");
-            uriComponentsBuilder.queryParam("urn", urn);
-            uriComponentsBuilder.queryParam("purpose", purpose);
-            uriComponentsBuilder.queryParam("pageSize", 50);
-            uriComponentsBuilder.queryParam("standalone", standalone);
-            UriComponents url = uriComponentsBuilder.build();
+            if (urn.contains(":video:")) {
+                UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.newInstance().scheme("http").host("peach.ebu.io").path("api/v1/chrts/continuous_playback_mobile");
+                uriComponentsBuilder.queryParam("urn", urn);
+                uriComponentsBuilder.queryParam("purpose", purpose);
+                uriComponentsBuilder.queryParam("pageSize", 50);
+                uriComponentsBuilder.queryParam("standalone", standalone);
+                UriComponents url = uriComponentsBuilder.build();
 
-            System.out.println(url.toUriString());
+                System.out.println(url.toUriString());
 
-            RecommendationResult recommendationResult = restTemplate.exchange(url.toUriString(), HttpMethod.GET, null, RecommendationResult.class).getBody();
-            return new RecommendedList(url.getHost(), recommendationResult.getRecommendationId(), recommendationResult.getUrns());
+                RecommendationResult recommendationResult = restTemplate.exchange(url.toUriString(), HttpMethod.GET, null, RecommendationResult.class).getBody();
+                return new RecommendedList(url.getHost(), recommendationResult.getRecommendationId(), recommendationResult.getUrns());
+            }
+            else {
+                Media media = integrationLayerRequest.getMedia(urn, Environment.PROD);
+                if (media == null || media.getType() == LIVESTREAM || media.getType() == SCHEDULED_LIVESTREAM || media.getShow() == null) {
+                    return new RecommendedList();
+                }
+
+                EpisodeComposition episodeComposition = integrationLayerRequest.getEpisodeCompositionLatestByShow(media.getShow().getUrn(), null, Environment.PROD);
+                if (episodeComposition == null) {
+                    new RecommendedList();
+                }
+
+                List<EpisodeWithMedias> episodes = Lists.reverse(episodeComposition.getList());
+                List<String> fullLengthUrns = episodes.stream().map(EpisodeWithMedias::getFullLengthUrn).collect(Collectors.toList());
+                List<String> clipUrns = episodes.stream().flatMap(e -> e.getMediaList().stream().filter(m -> m.getMediaType() == MediaType.AUDIO)).map(Media::getUrn).collect(Collectors.toList());
+                clipUrns.removeAll(fullLengthUrns);
+
+                Boolean isFullLengthUrns = false;
+                List<String> recommendationResult = null;
+
+                if (fullLengthUrns.contains(urn)) {
+                    isFullLengthUrns = true;
+                    int index = fullLengthUrns.lastIndexOf(urn);
+                    if (index < fullLengthUrns.size() - 1) {
+                        recommendationResult = fullLengthUrns.subList(index + 1, fullLengthUrns.size());
+                    }
+                    else {
+                        recommendationResult = new ArrayList<>();
+                    }
+                }
+                else if (clipUrns.contains(urn)) {
+                    isFullLengthUrns = false;
+                    int index = clipUrns.lastIndexOf(urn);
+                    if (index < clipUrns.size() - 1) {
+                        recommendationResult = clipUrns.subList(index + 1, clipUrns.size());
+                    }
+                    else {
+                        recommendationResult = new ArrayList<>();
+                    }
+                }
+                else {
+                    isFullLengthUrns = media.getType() != CLIP;
+                    recommendationResult = isFullLengthUrns ? fullLengthUrns : clipUrns;
+                }
+
+                String host = "playfff.srgssr.ch";
+                String recommendationId = "EpisodeComposition/LatestByShow/" + (isFullLengthUrns ? "FullLength" : "Clip");
+
+                if (recommendationResult.size() > 50) {
+                    recommendationResult = recommendationResult.subList(0, 51);
+                }
+
+                return new RecommendedList(host, recommendationId, recommendationResult);
+            }
         }
         else {
             return new RecommendedList();

--- a/src/main/java/com/example/pfff/service/RecommendationService.java
+++ b/src/main/java/com/example/pfff/service/RecommendationService.java
@@ -36,7 +36,7 @@ public class RecommendationService {
     public RecommendedList getRecommendedUrns(String purpose, String urn, boolean standalone) {
         if (urn.contains(":rts:")) {
             if (urn.contains(":video:")) {
-                return videoRecommendedList(purpose, urn, standalone);
+                return rtsVideoRecommendedList(purpose, urn, standalone);
             } else if (urn.contains(":audio:")) {
                 Media media = integrationLayerRequest.getMedia(urn, Environment.PROD);
                 if (media == null || media.getType() == LIVESTREAM || media.getType() == SCHEDULED_LIVESTREAM || media.getShow() == null) {
@@ -106,7 +106,7 @@ public class RecommendationService {
         }
     }
 
-    private RecommendedList videoRecommendedList(String purpose, String urn, boolean standalone) {
+    private RecommendedList rtsVideoRecommendedList(String purpose, String urn, boolean standalone) {
         UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.newInstance().scheme("http")
                 .host("peach.ebu.io").path("api/v1/chrts/continuous_playback_mobile");
         uriComponentsBuilder.queryParam("urn", urn);

--- a/src/main/java/com/example/pfff/service/RecommendationService.java
+++ b/src/main/java/com/example/pfff/service/RecommendationService.java
@@ -36,17 +36,7 @@ public class RecommendationService {
     public RecommendedList getRecommendedUrns(String purpose, String urn, boolean standalone) {
         if (urn.contains(":rts:")) {
             if (urn.contains(":video:")) {
-                UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.newInstance().scheme("http").host("peach.ebu.io").path("api/v1/chrts/continuous_playback_mobile");
-                uriComponentsBuilder.queryParam("urn", urn);
-                uriComponentsBuilder.queryParam("purpose", purpose);
-                uriComponentsBuilder.queryParam("pageSize", 49);
-                uriComponentsBuilder.queryParam("standalone", standalone);
-                UriComponents url = uriComponentsBuilder.build();
-
-                System.out.println(url.toUriString());
-
-                RecommendationResult recommendationResult = restTemplate.exchange(url.toUriString(), HttpMethod.GET, null, RecommendationResult.class).getBody();
-                return new RecommendedList(url.getHost(), recommendationResult.getRecommendationId(), recommendationResult.getUrns());
+                return videoRecommendedList(purpose, urn, standalone);
             }
             else if (urn.contains(":audio:")) {
                 Media media = integrationLayerRequest.getMedia(urn, Environment.PROD);
@@ -121,5 +111,22 @@ public class RecommendationService {
         else {
             return new RecommendedList();
         }
+    }
+
+    private RecommendedList videoRecommendedList(String purpose, String urn, boolean standalone) {
+        UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.newInstance().scheme("http")
+                .host("peach.ebu.io").path("api/v1/chrts/continuous_playback_mobile");
+        uriComponentsBuilder.queryParam("urn", urn);
+        uriComponentsBuilder.queryParam("purpose", purpose);
+        uriComponentsBuilder.queryParam("pageSize", 49);
+        uriComponentsBuilder.queryParam("standalone", standalone);
+        UriComponents url = uriComponentsBuilder.build();
+
+        System.out.println(url.toUriString());
+
+        RecommendationResult recommendationResult = restTemplate
+                .exchange(url.toUriString(), HttpMethod.GET, null, RecommendationResult.class).getBody();
+        return new RecommendedList(url.getHost(), recommendationResult.getRecommendationId(),
+                recommendationResult.getUrns());
     }
 }

--- a/src/test/java/com/example/pfff/controller/RecommendationIntegrationTest.java
+++ b/src/test/java/com/example/pfff/controller/RecommendationIntegrationTest.java
@@ -38,8 +38,22 @@ public class RecommendationIntegrationTest {
     }
 
     @Test
-    public void getRecommendationRTS() throws Exception {
+    public void getRecommendationRTSVideo() throws Exception {
         String mediaURN = "urn:rts:video:9691670";
+
+        getRecommendation(mediaURN);
+    }
+
+    @Test
+    public void getRecommendationRTSVAudioFull() throws Exception {
+        String mediaURN = "urn:rts:audio:9866170";
+
+        getRecommendation(mediaURN);
+    }
+
+    @Test
+    public void getRecommendationRTSVAudioClip() throws Exception {
+        String mediaURN = "urn:rts:audio:10163388";
 
         getRecommendation(mediaURN);
     }
@@ -76,8 +90,22 @@ public class RecommendationIntegrationTest {
     }
 
     @Test
-    public void getRecommendationRTSURNFormat() throws Exception {
+    public void getRecommendationRTSVideoURNFormat() throws Exception {
         String mediaURN = "urn:rts:video:9691670";
+
+        getRecommendationURNFormat(mediaURN, true);
+    }
+
+    @Test
+    public void getRecommendationRTSAudioFullURNFormat() throws Exception {
+        String mediaURN = "urn:rts:audio:9866170";
+
+        getRecommendationURNFormat(mediaURN, true);
+    }
+
+    @Test
+    public void getRecommendationRTSAudioClipURNFormat() throws Exception {
+        String mediaURN = "urn:rts:audio:10163388";
 
         getRecommendationURNFormat(mediaURN, true);
     }

--- a/src/test/java/com/example/pfff/controller/RecommendationServiceAudioResultTests.java
+++ b/src/test/java/com/example/pfff/controller/RecommendationServiceAudioResultTests.java
@@ -53,7 +53,7 @@ public class RecommendationServiceAudioResultTests {
         String urn = "urn:rts:audio:1";
         List<String> expectedUrns = Arrays.asList("urn:rts:audio:2", "urn:rts:audio:3", "urn:rts:audio:4");
 
-        testAudioFullLength(urn, true, expectedUrns);
+        testAudioRecommendation(urn, true,true, expectedUrns);
     }
 
     @Test
@@ -61,7 +61,7 @@ public class RecommendationServiceAudioResultTests {
         String urn = "urn:rts:audio:1";
         List<String> expectedUrns = Arrays.asList("urn:rts:audio:2", "urn:rts:audio:3", "urn:rts:audio:4");
 
-        testAudioFullLength(urn, false, expectedUrns);
+        testAudioRecommendation(urn, true,false, expectedUrns);
     }
 
     @Test
@@ -69,7 +69,7 @@ public class RecommendationServiceAudioResultTests {
         String urn = "urn:rts:audio:2";
         List<String> expectedUrns = Arrays.asList("urn:rts:audio:3", "urn:rts:audio:4", "urn:rts:audio:1");
 
-        testAudioFullLength(urn, true, expectedUrns);
+        testAudioRecommendation(urn, true,true, expectedUrns);
     }
 
     @Test
@@ -77,7 +77,7 @@ public class RecommendationServiceAudioResultTests {
         String urn = "urn:rts:audio:2";
         List<String> expectedUrns = Arrays.asList("urn:rts:audio:3", "urn:rts:audio:4", "urn:rts:audio:1");
 
-        testAudioFullLength(urn, false, expectedUrns);
+        testAudioRecommendation(urn, true,false, expectedUrns);
     }
 
     @Test
@@ -85,7 +85,7 @@ public class RecommendationServiceAudioResultTests {
         String urn = "urn:rts:audio:3";
         List<String> expectedUrns = Arrays.asList("urn:rts:audio:4", "urn:rts:audio:2", "urn:rts:audio:1");
 
-        testAudioFullLength(urn, true, expectedUrns);
+        testAudioRecommendation(urn, true,true, expectedUrns);
     }
 
     @Test
@@ -93,7 +93,7 @@ public class RecommendationServiceAudioResultTests {
         String urn = "urn:rts:audio:3";
         List<String> expectedUrns = Arrays.asList("urn:rts:audio:4", "urn:rts:audio:1", "urn:rts:audio:2");
 
-        testAudioFullLength(urn, false, expectedUrns);
+        testAudioRecommendation(urn, true,false, expectedUrns);
     }
 
     @Test
@@ -101,7 +101,7 @@ public class RecommendationServiceAudioResultTests {
         String urn = "urn:rts:audio:4";
         List<String> expectedUrns = Arrays.asList("urn:rts:audio:3", "urn:rts:audio:2", "urn:rts:audio:1");
 
-        testAudioFullLength(urn, true, expectedUrns);
+        testAudioRecommendation(urn, true,true, expectedUrns);
     }
 
     @Test
@@ -109,7 +109,7 @@ public class RecommendationServiceAudioResultTests {
         String urn = "urn:rts:audio:4";
         List<String> expectedUrns = Arrays.asList("urn:rts:audio:1", "urn:rts:audio:2", "urn:rts:audio:3");
 
-        testAudioFullLength(urn, false, expectedUrns);
+        testAudioRecommendation(urn, true,false, expectedUrns);
     }
 
     @Test
@@ -117,7 +117,7 @@ public class RecommendationServiceAudioResultTests {
         String urn = "urn:rts:audio:0";
         List<String> expectedUrns = Arrays.asList("urn:rts:audio:4", "urn:rts:audio:3", "urn:rts:audio:2", "urn:rts:audio:1");
 
-        testAudioFullLength(urn, true, expectedUrns);
+        testAudioRecommendation(urn, true,true, expectedUrns);
     }
 
     @Test
@@ -125,10 +125,74 @@ public class RecommendationServiceAudioResultTests {
         String urn = "urn:rts:audio:0";
         List<String> expectedUrns = Arrays.asList("urn:rts:audio:1", "urn:rts:audio:2", "urn:rts:audio:3", "urn:rts:audio:4");
 
-        testAudioFullLength(urn, false, expectedUrns);
+        testAudioRecommendation(urn, true,false, expectedUrns);
     }
 
-    private void testAudioFullLength(String urn, boolean hasNextUrl, List<String> expectedUrns) throws URISyntaxException {
+    @Test
+    public void audioClipAndNextURLforOldestEpisodeTest() throws URISyntaxException {
+        String urn = "urn:rts:audio:11";
+        List<String> expectedUrns = Arrays.asList("urn:rts:audio:12", "urn:rts:audio:21", "urn:rts:audio:22", "urn:rts:audio:31", "urn:rts:audio:32", "urn:rts:audio:41", "urn:rts:audio:42");
+
+        testAudioRecommendation(urn, false,true, expectedUrns);
+    }
+
+    @Test
+    public void audioClipforOldestEpisodeTest() throws URISyntaxException {
+        String urn = "urn:rts:audio:11";
+        List<String> expectedUrns = Arrays.asList("urn:rts:audio:12", "urn:rts:audio:21", "urn:rts:audio:22", "urn:rts:audio:31", "urn:rts:audio:32", "urn:rts:audio:41", "urn:rts:audio:42");
+
+        testAudioRecommendation(urn, false,false, expectedUrns);
+    }
+
+    @Test
+    public void audioClipAndNextURLforThirdEpisodeTest() throws URISyntaxException {
+        String urn = "urn:rts:audio:31";
+        List<String> expectedUrns = Arrays.asList("urn:rts:audio:32", "urn:rts:audio:41", "urn:rts:audio:42", "urn:rts:audio:22", "urn:rts:audio:21", "urn:rts:audio:12", "urn:rts:audio:11");
+
+        testAudioRecommendation(urn, false,true, expectedUrns);
+    }
+
+    @Test
+    public void audioClipforThirdEpisodeTest() throws URISyntaxException {
+        String urn = "urn:rts:audio:31";
+        List<String> expectedUrns = Arrays.asList("urn:rts:audio:32", "urn:rts:audio:41", "urn:rts:audio:42", "urn:rts:audio:11", "urn:rts:audio:12", "urn:rts:audio:21", "urn:rts:audio:22");
+
+        testAudioRecommendation(urn, false,false, expectedUrns);
+    }
+
+    @Test
+    public void audioClipAndNextURLforNewestEpisodeTest() throws URISyntaxException {
+        String urn = "urn:rts:audio:42";
+        List<String> expectedUrns = Arrays.asList("urn:rts:audio:41", "urn:rts:audio:32", "urn:rts:audio:31", "urn:rts:audio:22", "urn:rts:audio:21", "urn:rts:audio:12", "urn:rts:audio:11");
+
+        testAudioRecommendation(urn, false,true, expectedUrns);
+    }
+
+    @Test
+    public void audioClipforNewestEpisodeTest() throws URISyntaxException {
+        String urn = "urn:rts:audio:42";
+        List<String> expectedUrns = Arrays.asList("urn:rts:audio:11", "urn:rts:audio:12", "urn:rts:audio:21", "urn:rts:audio:22", "urn:rts:audio:31", "urn:rts:audio:32", "urn:rts:audio:41");
+
+        testAudioRecommendation(urn, false,false, expectedUrns);
+    }
+
+    @Test
+    public void audioClipAndNextURLforNotFoundEpisodeTest() throws URISyntaxException {
+        String urn = "urn:rts:audio:01";
+        List<String> expectedUrns = Arrays.asList("urn:rts:audio:42", "urn:rts:audio:41", "urn:rts:audio:32", "urn:rts:audio:31", "urn:rts:audio:22", "urn:rts:audio:21", "urn:rts:audio:12", "urn:rts:audio:11");
+
+        testAudioRecommendation(urn, false,true, expectedUrns);
+    }
+
+    @Test
+    public void audioClipforNotFoundEpisodeTest() throws URISyntaxException {
+        String urn = "urn:rts:audio:01";
+        List<String> expectedUrns = Arrays.asList("urn:rts:audio:11", "urn:rts:audio:12", "urn:rts:audio:21", "urn:rts:audio:22", "urn:rts:audio:31", "urn:rts:audio:32", "urn:rts:audio:41", "urn:rts:audio:42");
+
+        testAudioRecommendation(urn, false,false, expectedUrns);
+    }
+
+    private void testAudioRecommendation(String urn, boolean isFullLength, boolean episodeCompositionHasNextUrl, List<String> expectedUrns) throws URISyntaxException {
         String mediaFileName = urn.replace(":", "-") + ".json";
         String mediaJson1 = BaseResourceString.getString(applicationContext, mediaFileName, new HashMap<>());
         mockServer.expect(ExpectedCount.manyTimes(),
@@ -139,7 +203,7 @@ public class RecommendationServiceAudioResultTests {
                         .body(mediaJson1)
                 );
 
-        String episodeCompositionFileName = hasNextUrl ? "episode-compositision-radio-next-url.json" : "episode-compositision-radio.json";
+        String episodeCompositionFileName = episodeCompositionHasNextUrl ? "episode-compositision-radio-next-url.json" : "episode-compositision-radio.json";
         String episodeCompositionJson = BaseResourceString.getString(applicationContext, episodeCompositionFileName, new HashMap<>());
         mockServer.expect(ExpectedCount.manyTimes(),
                 requestTo(new URI("http://il.srgssr.ch:80/integrationlayer/2.0/episodeComposition/latestByShow/byUrn/urn:rts:show:radio:1234.json?pageSize=100")))
@@ -149,14 +213,16 @@ public class RecommendationServiceAudioResultTests {
                         .body(episodeCompositionJson)
                 );
 
+        String expectedRecommendationId = isFullLength ? "ch.srgssr.playfff:EpisodeComposition/LatestByShow/FullLength" : "ch.srgssr.playfff:EpisodeComposition/LatestByShow/Clip";
+
         RecommendedList recommendedList1 = recommendationService.getRecommendedUrns("continuousplayback", urn, false);
         Assert.assertNotNull(recommendedList1);
-        Assert.assertEquals(recommendedList1.getRecommendationId(), "ch.srgssr.playfff:EpisodeComposition/LatestByShow/FullLength");
+        Assert.assertEquals(recommendedList1.getRecommendationId(), expectedRecommendationId);
         Assert.assertEquals(recommendedList1.getUrns(), expectedUrns);
 
         RecommendedList recommendedList2 = recommendationService.getRecommendedUrns("continuousplayback", urn, true);
         Assert.assertNotNull(recommendedList2);
-        Assert.assertEquals(recommendedList2.getRecommendationId(), "ch.srgssr.playfff:EpisodeComposition/LatestByShow/FullLength");
+        Assert.assertEquals(recommendedList2.getRecommendationId(), expectedRecommendationId);
         Assert.assertEquals(recommendedList2.getUrns(), expectedUrns);
     }
 }

--- a/src/test/java/com/example/pfff/controller/RecommendationServiceAudioResultTests.java
+++ b/src/test/java/com/example/pfff/controller/RecommendationServiceAudioResultTests.java
@@ -1,0 +1,162 @@
+package com.example.pfff.controller;
+
+import com.example.pfff.helper.BaseResourceString;
+import com.example.pfff.model.RecommendedList;
+import com.example.pfff.service.IntegrationLayerRequest;
+import com.example.pfff.service.RecommendationService;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.client.ExpectedCount;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class RecommendationServiceAudioResultTests {
+
+    @Autowired
+    private RecommendationService recommendationService;
+
+    @Autowired
+    private IntegrationLayerRequest integrationLayerRequest;
+
+    @Autowired
+    protected ApplicationContext applicationContext;
+
+    private MockRestServiceServer mockServer;
+
+    @Before
+    public void init() {
+        mockServer = MockRestServiceServer.createServer(integrationLayerRequest.getRestTemplate());
+    }
+
+    @Test
+    public void audioFullLengthAndNextURLforOldestEpisodeTest() throws URISyntaxException {
+        String urn = "urn:rts:audio:1";
+        List<String> expectedUrns = Arrays.asList("urn:rts:audio:2", "urn:rts:audio:3", "urn:rts:audio:4");
+
+        testAudioFullLength(urn, true, expectedUrns);
+    }
+
+    @Test
+    public void audioFullLengthforOldestEpisodeTest() throws URISyntaxException {
+        String urn = "urn:rts:audio:1";
+        List<String> expectedUrns = Arrays.asList("urn:rts:audio:2", "urn:rts:audio:3", "urn:rts:audio:4");
+
+        testAudioFullLength(urn, false, expectedUrns);
+    }
+
+    @Test
+    public void audioFullLengthAndNextURLforSecondEpisodeTest() throws URISyntaxException {
+        String urn = "urn:rts:audio:2";
+        List<String> expectedUrns = Arrays.asList("urn:rts:audio:3", "urn:rts:audio:4", "urn:rts:audio:1");
+
+        testAudioFullLength(urn, true, expectedUrns);
+    }
+
+    @Test
+    public void audioFullLengthforSecondEpisodeTest() throws URISyntaxException {
+        String urn = "urn:rts:audio:2";
+        List<String> expectedUrns = Arrays.asList("urn:rts:audio:3", "urn:rts:audio:4", "urn:rts:audio:1");
+
+        testAudioFullLength(urn, false, expectedUrns);
+    }
+
+    @Test
+    public void audioFullLengthAndNextURLforThirdEpisodeTest() throws URISyntaxException {
+        String urn = "urn:rts:audio:3";
+        List<String> expectedUrns = Arrays.asList("urn:rts:audio:4", "urn:rts:audio:2", "urn:rts:audio:1");
+
+        testAudioFullLength(urn, true, expectedUrns);
+    }
+
+    @Test
+    public void audioFullLengthforThirdEpisodeTest() throws URISyntaxException {
+        String urn = "urn:rts:audio:3";
+        List<String> expectedUrns = Arrays.asList("urn:rts:audio:4", "urn:rts:audio:1", "urn:rts:audio:2");
+
+        testAudioFullLength(urn, false, expectedUrns);
+    }
+
+    @Test
+    public void audioFullLengthAndNextURLforNewestEpisodeTest() throws URISyntaxException {
+        String urn = "urn:rts:audio:4";
+        List<String> expectedUrns = Arrays.asList("urn:rts:audio:3", "urn:rts:audio:2", "urn:rts:audio:1");
+
+        testAudioFullLength(urn, true, expectedUrns);
+    }
+
+    @Test
+    public void audioFullLengthforNewestEpisodeTest() throws URISyntaxException {
+        String urn = "urn:rts:audio:4";
+        List<String> expectedUrns = Arrays.asList("urn:rts:audio:1", "urn:rts:audio:2", "urn:rts:audio:3");
+
+        testAudioFullLength(urn, false, expectedUrns);
+    }
+
+    @Test
+    public void audioFullLengthAndNextURLforNotFoundEpisodeTest() throws URISyntaxException {
+        String urn = "urn:rts:audio:0";
+        List<String> expectedUrns = Arrays.asList("urn:rts:audio:4", "urn:rts:audio:3", "urn:rts:audio:2", "urn:rts:audio:1");
+
+        testAudioFullLength(urn, true, expectedUrns);
+    }
+
+    @Test
+    public void audioFullLengthforNotFoundEpisodeTest() throws URISyntaxException {
+        String urn = "urn:rts:audio:0";
+        List<String> expectedUrns = Arrays.asList("urn:rts:audio:1", "urn:rts:audio:2", "urn:rts:audio:3", "urn:rts:audio:4");
+
+        testAudioFullLength(urn, false, expectedUrns);
+    }
+
+    private void testAudioFullLength(String urn, boolean hasNextUrl, List<String> expectedUrns) throws URISyntaxException {
+        String mediaFileName = urn.replace(":", "-") + ".json";
+        String mediaJson1 = BaseResourceString.getString(applicationContext, mediaFileName, new HashMap<>());
+        mockServer.expect(ExpectedCount.manyTimes(),
+                requestTo(new URI("http://il.srgssr.ch:80/integrationlayer/2.0/media/byUrn/"+ urn + ".json")))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(mediaJson1)
+                );
+
+        String episodeCompositionFileName = hasNextUrl ? "episode-compositision-radio-next-url.json" : "episode-compositision-radio.json";
+        String episodeCompositionJson = BaseResourceString.getString(applicationContext, episodeCompositionFileName, new HashMap<>());
+        mockServer.expect(ExpectedCount.manyTimes(),
+                requestTo(new URI("http://il.srgssr.ch:80/integrationlayer/2.0/episodeComposition/latestByShow/byUrn/urn:rts:show:radio:1234.json?pageSize=100")))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(episodeCompositionJson)
+                );
+
+        RecommendedList recommendedList1 = recommendationService.getRecommendedUrns("continuousplayback", urn, false);
+        Assert.assertNotNull(recommendedList1);
+        Assert.assertEquals(recommendedList1.getRecommendationId(), "ch.srgssr.playfff:EpisodeComposition/LatestByShow/FullLength");
+        Assert.assertEquals(recommendedList1.getUrns(), expectedUrns);
+
+        RecommendedList recommendedList2 = recommendationService.getRecommendedUrns("continuousplayback", urn, true);
+        Assert.assertNotNull(recommendedList2);
+        Assert.assertEquals(recommendedList2.getRecommendationId(), "ch.srgssr.playfff:EpisodeComposition/LatestByShow/FullLength");
+        Assert.assertEquals(recommendedList2.getUrns(), expectedUrns);
+    }
+}

--- a/src/test/java/com/example/pfff/controller/RecommendationServiceAudioResultTests.java
+++ b/src/test/java/com/example/pfff/controller/RecommendationServiceAudioResultTests.java
@@ -4,6 +4,7 @@ import com.example.pfff.helper.BaseResourceString;
 import com.example.pfff.model.RecommendedList;
 import com.example.pfff.service.IntegrationLayerRequest;
 import com.example.pfff.service.RecommendationService;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -17,6 +18,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.client.ExpectedCount;
 import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -42,10 +44,20 @@ public class RecommendationServiceAudioResultTests {
     protected ApplicationContext applicationContext;
 
     private MockRestServiceServer mockServer;
+    private  RestTemplate mockRestTemplate = new RestTemplate();
+
+    private  RestTemplate savedRestTemplate;
 
     @Before
     public void init() {
-        mockServer = MockRestServiceServer.createServer(integrationLayerRequest.getRestTemplate());
+        savedRestTemplate = integrationLayerRequest.getRestTemplate();
+        integrationLayerRequest.setRestTemplate(mockRestTemplate);
+        mockServer = MockRestServiceServer.createServer(mockRestTemplate);
+    }
+
+    @After
+    public void finish() {
+        integrationLayerRequest.setRestTemplate(savedRestTemplate);
     }
 
     @Test
@@ -224,5 +236,7 @@ public class RecommendationServiceAudioResultTests {
         Assert.assertNotNull(recommendedList2);
         Assert.assertEquals(recommendedList2.getRecommendationId(), expectedRecommendationId);
         Assert.assertEquals(recommendedList2.getUrns(), expectedUrns);
+
+        mockServer.verify();
     }
 }

--- a/src/test/java/com/example/pfff/controller/RecommendationServiceTests.java
+++ b/src/test/java/com/example/pfff/controller/RecommendationServiceTests.java
@@ -19,7 +19,7 @@ public class RecommendationServiceTests {
     private RecommendationService recommendationService;
 
     @Test
-    public void getRecommendedUrnsContinuousplaybackRTSTest() {
+    public void getRecommendedUrnsContinuousplaybackRTSVideoTest() {
         String purpose = "continuousplayback";
         String mediaURN = "urn:rts:video:9691670";
         boolean standalone = false;
@@ -33,7 +33,7 @@ public class RecommendationServiceTests {
     }
 
     @Test
-    public void getRecommendedUrnsContinuousplaybackStandaloneRTSTest() {
+    public void getRecommendedUrnsContinuousplaybackStandaloneRTSVideoTest() {
         String purpose = "continuousplayback";
         String mediaURN = "urn:rts:video:9691670";
         boolean standalone = true;
@@ -41,6 +41,62 @@ public class RecommendationServiceTests {
 
         Assert.assertNotNull(recommendedList.getRecommendationId());
         Assert.assertTrue(recommendedList.getRecommendationId().startsWith("io.ebu.peach:"));
+        Assert.assertNotNull(recommendedList.getUrns());
+        Assert.assertTrue(recommendedList.getUrns().size() > 0);
+        Assert.assertTrue(recommendedList.getUrns().size() < 50);
+    }
+
+    @Test
+    public void getRecommendedUrnsContinuousplaybackRTSAudioFullTest() {
+        String purpose = "continuousplayback";
+        String mediaURN = "urn:rts:audio:9866170";
+        boolean standalone = false;
+        RecommendedList recommendedList = recommendationService.getRecommendedUrns(purpose, mediaURN, standalone);
+
+        Assert.assertNotNull(recommendedList.getRecommendationId());
+        Assert.assertEquals(recommendedList.getRecommendationId(),"ch.srgssr.playfff:EpisodeComposition/LatestByShow/FullLength");
+        Assert.assertNotNull(recommendedList.getUrns());
+        Assert.assertTrue(recommendedList.getUrns().size() > 0);
+        Assert.assertTrue(recommendedList.getUrns().size() < 50);
+    }
+
+    @Test
+    public void getRecommendedUrnsContinuousplaybackStandaloneRTSAudioFullTest() {
+        String purpose = "continuousplayback";
+        String mediaURN = "urn:rts:audio:9866170";
+        boolean standalone = true;
+        RecommendedList recommendedList = recommendationService.getRecommendedUrns(purpose, mediaURN, standalone);
+
+        Assert.assertNotNull(recommendedList.getRecommendationId());
+        Assert.assertEquals(recommendedList.getRecommendationId(), "ch.srgssr.playfff:EpisodeComposition/LatestByShow/FullLength");
+        Assert.assertNotNull(recommendedList.getUrns());
+        Assert.assertTrue(recommendedList.getUrns().size() > 0);
+        Assert.assertTrue(recommendedList.getUrns().size() < 50);
+    }
+
+    @Test
+    public void getRecommendedUrnsContinuousplaybackRTSAudioClipTest() {
+        String purpose = "continuousplayback";
+        String mediaURN = "urn:rts:audio:10163388";
+        boolean standalone = false;
+        RecommendedList recommendedList = recommendationService.getRecommendedUrns(purpose, mediaURN, standalone);
+
+        Assert.assertNotNull(recommendedList.getRecommendationId());
+        Assert.assertEquals(recommendedList.getRecommendationId(), "ch.srgssr.playfff:EpisodeComposition/LatestByShow/Clip");
+        Assert.assertNotNull(recommendedList.getUrns());
+        Assert.assertTrue(recommendedList.getUrns().size() > 0);
+        Assert.assertTrue(recommendedList.getUrns().size() < 50);
+    }
+
+    @Test
+    public void getRecommendedUrnsContinuousplaybackStandaloneRTSAudioClipTest() {
+        String purpose = "continuousplayback";
+        String mediaURN = "urn:rts:audio:10163388";
+        boolean standalone = true;
+        RecommendedList recommendedList = recommendationService.getRecommendedUrns(purpose, mediaURN, standalone);
+
+        Assert.assertNotNull(recommendedList.getRecommendationId());
+        Assert.assertEquals(recommendedList.getRecommendationId(), "ch.srgssr.playfff:EpisodeComposition/LatestByShow/Clip");
         Assert.assertNotNull(recommendedList.getUrns());
         Assert.assertTrue(recommendedList.getUrns().size() > 0);
         Assert.assertTrue(recommendedList.getUrns().size() < 50);

--- a/src/test/java/com/example/pfff/controller/RecommendationServiceTests.java
+++ b/src/test/java/com/example/pfff/controller/RecommendationServiceTests.java
@@ -28,6 +28,8 @@ public class RecommendationServiceTests {
         Assert.assertNotNull(recommendedList.getRecommendationId());
         Assert.assertTrue(recommendedList.getRecommendationId().startsWith("io.ebu.peach:"));
         Assert.assertNotNull(recommendedList.getUrns());
+        Assert.assertTrue(recommendedList.getUrns().size() > 0);
+        Assert.assertTrue(recommendedList.getUrns().size() < 50);
     }
 
     @Test
@@ -40,6 +42,8 @@ public class RecommendationServiceTests {
         Assert.assertNotNull(recommendedList.getRecommendationId());
         Assert.assertTrue(recommendedList.getRecommendationId().startsWith("io.ebu.peach:"));
         Assert.assertNotNull(recommendedList.getUrns());
+        Assert.assertTrue(recommendedList.getUrns().size() > 0);
+        Assert.assertTrue(recommendedList.getUrns().size() < 50);
     }
 
     @Test
@@ -51,6 +55,7 @@ public class RecommendationServiceTests {
 
         Assert.assertNull(recommendedList.getRecommendationId());
         Assert.assertNotNull(recommendedList.getUrns());
+        Assert.assertEquals(recommendedList.getUrns().size(), 0);
     }
 
     @Test
@@ -62,6 +67,7 @@ public class RecommendationServiceTests {
 
         Assert.assertNull(recommendedList.getRecommendationId());
         Assert.assertNotNull(recommendedList.getUrns());
+        Assert.assertEquals(recommendedList.getUrns().size(), 0);
     }
 
     @Test
@@ -73,6 +79,7 @@ public class RecommendationServiceTests {
 
         Assert.assertNull(recommendedList.getRecommendationId());
         Assert.assertNotNull(recommendedList.getUrns());
+        Assert.assertEquals(recommendedList.getUrns().size(), 0);
     }
 
     @Test
@@ -84,5 +91,6 @@ public class RecommendationServiceTests {
 
         Assert.assertNull(recommendedList.getRecommendationId());
         Assert.assertNotNull(recommendedList.getUrns());
+        Assert.assertEquals(recommendedList.getUrns().size(), 0);
     }
 }

--- a/src/test/java/com/example/pfff/helper/BaseResourceString.java
+++ b/src/test/java/com/example/pfff/helper/BaseResourceString.java
@@ -1,0 +1,34 @@
+package com.example.pfff.helper;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.io.Resource;
+import org.springframework.util.StreamUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+/**
+ * Created by seb on 10/08/16.
+ */
+public class BaseResourceString {
+    public static String getString(ApplicationContext applicationContext, String name, Map<String, String> variables) {
+        try {
+            Resource resource = applicationContext.getResource("classpath:" + name);
+            if (resource == null) {
+                throw new RuntimeException("No resource: " + name);
+            }
+            String s = StreamUtils.copyToString(resource.getInputStream(), StandardCharsets.UTF_8);
+            for (String k : variables.keySet()) {
+                String value = variables.get(k);
+                if (value == null) {
+                    throw new IllegalArgumentException(k + " has null value (" + name + ")");
+                }
+                s = s.replaceAll(k, value);
+            }
+            return s;
+        } catch (IOException e) {
+            throw new RuntimeException("IO Exception for " + name, e);
+        }
+    }
+}

--- a/src/test/resources/episode-compositision-radio-next-url.json
+++ b/src/test/resources/episode-compositision-radio-next-url.json
@@ -67,7 +67,7 @@
          "presentation" : "DEFAULT"
       }, {
          "id" : "43",
-         "mediaType" : "AUDIO",
+         "mediaType" : "VIDEO",
          "vendor" : "RTS",
          "urn" : "urn:rts:audio:43",
          "title" : "Le zoo jordanien qui recueille les animaux blessés de guerre",
@@ -131,7 +131,7 @@
          "presentation" : "DEFAULT"
       }, {
          "id" : "33",
-         "mediaType" : "AUDIO",
+         "mediaType" : "VIDEO",
          "vendor" : "RTS",
          "urn" : "urn:rts:audio:33",
          "title" : "Reportage, le long de la frontière entre les Etats-Unis et le Mexique (2/2)",
@@ -195,7 +195,7 @@
          "presentation" : "DEFAULT"
       }, {
          "id" : "23",
-         "mediaType" : "AUDIO",
+         "mediaType" : "VIDEO",
          "vendor" : "RTS",
          "urn" : "urn:rts:audio:23",
          "title" : "Reportage le long de la frontière entre les Etats-Unis et le Mexique (1/2)",
@@ -260,7 +260,7 @@
          "presentation" : "DEFAULT"
       }, {
          "id" : "13",
-         "mediaType" : "AUDIO",
+         "mediaType" : "VIDEO",
          "vendor" : "RTS",
          "urn" : "urn:rts:audio:13",
          "title" : "L'épouse de Meng Hongweim, ex-patron chinois d'Interpol, craint pour sa sécurité",

--- a/src/test/resources/episode-compositision-radio-next-url.json
+++ b/src/test/resources/episode-compositision-radio-next-url.json
@@ -1,0 +1,277 @@
+{
+   "next" : "http://il.srgssr.ch/integrationlayer/2.0/episodeComposition/latestByShow/byUrn/urn:rts:show:radio:1234.json?next=4c121f9f3e50606447bc5b3de0c652c4fbb3e0c95caec9af03fd3e0abf17c91b519d2c96c7f615aa",
+   "show" : {
+      "id" : "1234",
+      "vendor" : "RTS",
+      "transmission" : "RADIO",
+      "urn" : "urn:rts:show:radio:1234",
+      "title" : "Tout un monde",
+      "lead" : "Chaque matin, Eric Guevara-Frey et Patrick Chaboudez mettent la priorité sur l’actualité internationale avec les meilleurs experts, des acteurs internationaux, des reportages et des débats.",
+      "description" : "L'actualité internationale ne s'arrête jamais. Les tensions sont à nouveau vives, autour de la planète et la Suisse est souvent associée dans divers rôles aux principales thématiques internationales.  Pour comprendre ces enjeux, Eric Guevara-Frey et Patrick Chaboudez mettent la priorité sur l'actualité du monde avec les meilleurs experts, des acteurs internationaux, des reportages et des débats.",
+      "imageUrl" : "https://www.rts.ch/2016/06/10/08/29/7677657.image/16x9",
+      "imageTitle" : "Tout un monde [RTS]",
+      "homepageUrl" : "https://details.rts.ch/la-1ere/programmes/tout-un-monde/",
+      "podcastSubscriptionUrl" : "https://www.rts.ch/la-1ere/programmes/tout-un-monde/podcast/",
+      "primaryChannelId" : "a9e7621504c6959e35c3ecbe7f6bed0446cdf8da"
+   },
+   "episodeList" : [ {
+      "id" : "10166113",
+      "title" : "Tout un monde du 01.02.2019",
+      "publishedDate" : "2019-02-01T08:12:26+01:00",
+      "imageUrl" : "https://www.rts.ch/2017/03/03/18/06/8433653.image/16x9",
+      "imageTitle" : "Tout un monde [RTS]",
+      "fullLengthUrn" : "urn:rts:audio:4",
+      "socialCount" : {
+         "key" : "srgView",
+         "value" : 301
+      },
+      "mediaList" : [ {
+         "id" : "4",
+         "mediaType" : "AUDIO",
+         "vendor" : "RTS",
+         "urn" : "urn:rts:audio:4",
+         "title" : "Tout un monde - Présenté par Eric Guevara-Frey",
+         "description" : "Au sommaire: le mouvement antivaccin parmi les dix grandes menaces selon l’OMS; le point sur l’impact des sanctions en Iran; et le zoo jordanien qui recueille les animaux blessés de guerre.",
+         "imageUrl" : "https://www.rts.ch/2017/03/03/18/06/8433653.image/16x9",
+         "imageTitle" : "Tout un monde [RTS]",
+         "type" : "EPISODE",
+         "date" : "2019-02-01T08:12:26+01:00",
+         "duration" : 1424000,
+         "playableAbroad" : true,
+         "presentation" : "DEFAULT"
+      }, {
+         "id" : "41",
+         "mediaType" : "AUDIO",
+         "vendor" : "RTS",
+         "urn" : "urn:rts:audio:41",
+         "title" : "Le mouvement antivaccin parmi les dix grandes menaces selon l’OMS",
+         "imageUrl" : "https://www.rts.ch/2017/12/21/12/15/9193424.image/16x9",
+         "imageTitle" : "La fronde anti-vaccination a-t-elle toujours existé? [Ursule - Fotolia]",
+         "type" : "CLIP",
+         "date" : "2019-02-01T08:12:00+01:00",
+         "duration" : 560000,
+         "playableAbroad" : true,
+         "presentation" : "DEFAULT"
+      }, {
+         "id" : "42",
+         "mediaType" : "AUDIO",
+         "vendor" : "RTS",
+         "urn" : "urn:rts:audio:42",
+         "title" : "Le point sur l’impact des sanctions en Iran",
+         "imageUrl" : "https://www.rts.ch/2018/11/14/16/56/9995060.image/16x9",
+         "imageTitle" : "Une raffinerie de pétrole à Téhéran. (Image d'illustration). [Vahid Salemi - AP]",
+         "type" : "CLIP",
+         "date" : "2019-02-01T08:17:00+01:00",
+         "duration" : 448000,
+         "playableAbroad" : true,
+         "presentation" : "DEFAULT"
+      }, {
+         "id" : "43",
+         "mediaType" : "AUDIO",
+         "vendor" : "RTS",
+         "urn" : "urn:rts:audio:43",
+         "title" : "Le zoo jordanien qui recueille les animaux blessés de guerre",
+         "imageUrl" : "https://www.rts.ch/2019/02/01/16/46/10186367.image/16x9",
+         "imageTitle" : "Un tigre pensionnaire du centre Al Ma'wa en Jordanie, qui recueille des animaux rescapés de zones de guerre. [Rami Elakhras - DR]",
+         "type" : "CLIP",
+         "date" : "2019-02-01T08:22:00+01:00",
+         "duration" : 265000,
+         "playableAbroad" : true,
+         "presentation" : "DEFAULT"
+      } ]
+   }, {
+      "id" : "10163334",
+      "title" : "Tout un monde du 31.01.2019",
+      "publishedDate" : "2019-01-31T08:12:09+01:00",
+      "imageUrl" : "https://www.rts.ch/2016/06/10/08/29/7677657.image/16x9",
+      "imageTitle" : "Tout un monde [RTS]",
+      "fullLengthUrn" : "urn:rts:audio:3",
+      "socialCount" : {
+         "key" : "srgView",
+         "value" : 305
+      },
+      "mediaList" : [ {
+         "id" : "3",
+         "mediaType" : "AUDIO",
+         "vendor" : "RTS",
+         "urn" : "urn:rts:audio:3",
+         "title" : "Tout un monde - Présenté par Eric Guevara-Frey",
+         "imageUrl" : "https://www.rts.ch/2016/06/10/08/29/7677657.image/16x9",
+         "imageTitle" : "Tout un monde [RTS]",
+         "type" : "EPISODE",
+         "date" : "2019-01-31T08:12:09+01:00",
+         "duration" : 1412000,
+         "playableAbroad" : true,
+         "presentation" : "DEFAULT"
+      }, {
+         "id" : "31",
+         "mediaType" : "AUDIO",
+         "vendor" : "RTS",
+         "urn" : "urn:rts:audio:31",
+         "title" : "Les réformes à Shenzhen à l’origine du développement économique de toute la Chine",
+         "imageUrl" : "https://www.rts.ch/2018/12/07/16/10/10052379.image/16x9",
+         "imageTitle" : "En 2019, tous les taxis de Shenzeng rouleront à l'énergie électrique. [RTS]",
+         "type" : "CLIP",
+         "date" : "2019-01-31T08:12:00+01:00",
+         "duration" : 315000,
+         "playableAbroad" : true,
+         "presentation" : "DEFAULT"
+      }, {
+         "id" : "32",
+         "mediaType" : "AUDIO",
+         "vendor" : "RTS",
+         "urn" : "urn:rts:audio:32",
+         "title" : "L’OCDE annonce une campagne pour repenser la fiscalité face à la digitalisation des entreprises",
+         "imageUrl" : "https://www.rts.ch/2019/01/31/09/39/9822376.image/16x9",
+         "imageTitle" : "Le siège de l'OCDE, à Paris. [Charles Platiau - Reuters]",
+         "type" : "CLIP",
+         "date" : "2019-01-31T08:17:00+01:00",
+         "duration" : 628000,
+         "playableAbroad" : true,
+         "presentation" : "DEFAULT"
+      }, {
+         "id" : "33",
+         "mediaType" : "AUDIO",
+         "vendor" : "RTS",
+         "urn" : "urn:rts:audio:33",
+         "title" : "Reportage, le long de la frontière entre les Etats-Unis et le Mexique (2/2)",
+         "imageUrl" : "https://www.rts.ch/2019/01/31/10/57/10182319.image/16x9",
+         "imageTitle" : "Les migrants bloqués du côté mexicain de la frontière dans une situation précaire. [Eric Gay - Keystone/AP]",
+         "type" : "CLIP",
+         "date" : "2019-01-31T08:22:00+01:00",
+         "duration" : 376000,
+         "playableAbroad" : true,
+         "presentation" : "DEFAULT"
+      } ]
+   }, {
+      "id" : "10160597",
+      "title" : "Tout un monde du 30.01.2019",
+      "publishedDate" : "2019-01-30T08:11:53+01:00",
+      "imageUrl" : "https://www.rts.ch/2016/06/10/08/29/7677657.image/16x9",
+      "imageTitle" : "Tout un monde [RTS]",
+      "fullLengthUrn" : "urn:rts:audio:2",
+      "socialCount" : {
+         "key" : "srgView",
+         "value" : 448
+      },
+      "mediaList" : [ {
+         "id" : "2",
+         "mediaType" : "AUDIO",
+         "vendor" : "RTS",
+         "urn" : "urn:rts:audio:2",
+         "title" : "Tout un monde - Présenté par Eric Guevara-Frey",
+         "imageUrl" : "https://www.rts.ch/2016/06/10/08/29/7677657.image/16x9",
+         "imageTitle" : "Tout un monde [RTS]",
+         "type" : "EPISODE",
+         "date" : "2019-01-30T08:11:53+01:00",
+         "duration" : 1448000,
+         "playableAbroad" : true,
+         "presentation" : "DEFAULT"
+      }, {
+         "id" : "21",
+         "mediaType" : "AUDIO",
+         "vendor" : "RTS",
+         "urn" : "urn:rts:audio:21",
+         "title" : "La presse britannique mitigée sur la renégociation annoncée du Brexit",
+         "imageUrl" : "https://www.rts.ch/2019/01/30/06/59/10179357.image/16x9",
+         "imageTitle" : "Theresa May a obtenu un mandat pour renégocier l'accord sur le Brexit. [Mark Duffy - UK Parliament via AP/Keystone]",
+         "type" : "CLIP",
+         "date" : "2019-01-30T08:12:00+01:00",
+         "duration" : 171000,
+         "playableAbroad" : true,
+         "presentation" : "DEFAULT"
+      }, {
+         "id" : "22",
+         "mediaType" : "AUDIO",
+         "vendor" : "RTS",
+         "urn" : "urn:rts:audio:22",
+         "title" : "La crainte de la démocratie en Algérie",
+         "imageUrl" : "https://www.rts.ch/2019/01/29/18/23/8429776.image/16x9",
+         "imageTitle" : "L'actuel président algérien Abdelaziz Bouteflika. [Sidali Djarboub - AP/Keystone]",
+         "type" : "CLIP",
+         "date" : "2019-01-30T08:17:00+01:00",
+         "duration" : 366000,
+         "playableAbroad" : true,
+         "presentation" : "DEFAULT"
+      }, {
+         "id" : "23",
+         "mediaType" : "AUDIO",
+         "vendor" : "RTS",
+         "urn" : "urn:rts:audio:23",
+         "title" : "Reportage le long de la frontière entre les Etats-Unis et le Mexique (1/2)",
+         "imageUrl" : "https://www.rts.ch/2019/01/28/09/02/10172783.image/16x9",
+         "imageTitle" : "La frontière à Brownsville (Texas). [Raphaël Grand - RTS]",
+         "type" : "CLIP",
+         "date" : "2019-01-30T08:22:00+01:00",
+         "duration" : 435000,
+         "playableAbroad" : true,
+         "presentation" : "DEFAULT"
+      }
+      ]
+   }, {
+      "id" : "10157671",
+      "title" : "Tout un monde du 29.01.2019",
+      "publishedDate" : "2019-01-29T08:12:41+01:00",
+      "imageUrl" : "https://www.rts.ch/2016/06/10/08/29/7677657.image/16x9",
+      "imageTitle" : "Tout un monde [RTS]",
+      "fullLengthUrn" : "urn:rts:audio:1",
+      "socialCount" : {
+         "key" : "srgView",
+         "value" : 366
+      },
+      "mediaList" : [ {
+         "id" : "1",
+         "mediaType" : "AUDIO",
+         "vendor" : "RTS",
+         "urn" : "urn:rts:audio:1",
+         "title" : "Tout un monde - Présenté par Eric Guevara-Frey",
+         "imageUrl" : "https://www.rts.ch/2016/06/10/08/29/7677657.image/16x9",
+         "imageTitle" : "Tout un monde [RTS]",
+         "type" : "EPISODE",
+         "date" : "2019-01-29T08:12:41+01:00",
+         "duration" : 1380000,
+         "playableAbroad" : true,
+         "presentation" : "DEFAULT"
+      }, {
+         "id" : "11",
+         "mediaType" : "AUDIO",
+         "vendor" : "RTS",
+         "urn" : "urn:rts:audio:11",
+         "title" : "Le soutien à Theresa May dans sa circonscription d'origine, Maidenhead",
+         "imageUrl" : "https://www.rts.ch/2018/12/17/17/51/10077119.image/16x9",
+         "imageTitle" : "La Première ministre britannique, Theresa May, ne veut pas d'un nouveau référendum sur le Brexit. [epa/Will Oliver - Keystone]",
+         "type" : "CLIP",
+         "date" : "2019-01-29T08:12:00+01:00",
+         "duration" : 251000,
+         "playableAbroad" : true,
+         "presentation" : "DEFAULT"
+      }, {
+         "id" : "12",
+         "mediaType" : "AUDIO",
+         "vendor" : "RTS",
+         "urn" : "urn:rts:audio:12",
+         "title" : "Richard Quest, journaliste de CNN, tire le bilan du Forum économique de Davos",
+         "imageUrl" : "https://www.rts.ch/2019/01/28/18/49/9289640.image/16x9",
+         "imageTitle" : "Retour sur le WEF 2019 avec le journaliste économique américain Richard Quest. [CNN International]",
+         "type" : "CLIP",
+         "date" : "2019-01-29T08:17:00+01:00",
+         "duration" : 612000,
+         "playableAbroad" : true,
+         "presentation" : "DEFAULT"
+      }, {
+         "id" : "13",
+         "mediaType" : "AUDIO",
+         "vendor" : "RTS",
+         "urn" : "urn:rts:audio:13",
+         "title" : "L'épouse de Meng Hongweim, ex-patron chinois d'Interpol, craint pour sa sécurité",
+         "imageUrl" : "https://www.rts.ch/2019/01/18/16/28/10150042.image/16x9",
+         "imageTitle" : "Grace Meng (de dos) lors d'un entretien avec des journalistes en octobre 2018. [Jeff Pachoud - AFP]",
+         "type" : "CLIP",
+         "date" : "2019-01-29T08:22:00+01:00",
+         "duration" : 445000,
+         "playableAbroad" : true,
+         "presentation" : "DEFAULT"
+      } ]
+   }
+  ]
+}

--- a/src/test/resources/episode-compositision-radio.json
+++ b/src/test/resources/episode-compositision-radio.json
@@ -66,7 +66,7 @@
          "presentation" : "DEFAULT"
       }, {
          "id" : "43",
-         "mediaType" : "AUDIO",
+         "mediaType" : "VIDEO",
          "vendor" : "RTS",
          "urn" : "urn:rts:audio:43",
          "title" : "Le zoo jordanien qui recueille les animaux blessés de guerre",
@@ -130,7 +130,7 @@
          "presentation" : "DEFAULT"
       }, {
          "id" : "33",
-         "mediaType" : "AUDIO",
+         "mediaType" : "VIDEO",
          "vendor" : "RTS",
          "urn" : "urn:rts:audio:33",
          "title" : "Reportage, le long de la frontière entre les Etats-Unis et le Mexique (2/2)",
@@ -194,7 +194,7 @@
          "presentation" : "DEFAULT"
       }, {
          "id" : "23",
-         "mediaType" : "AUDIO",
+         "mediaType" : "VIDEO",
          "vendor" : "RTS",
          "urn" : "urn:rts:audio:23",
          "title" : "Reportage le long de la frontière entre les Etats-Unis et le Mexique (1/2)",
@@ -259,7 +259,7 @@
          "presentation" : "DEFAULT"
       }, {
          "id" : "13",
-         "mediaType" : "AUDIO",
+         "mediaType" : "VIDEO",
          "vendor" : "RTS",
          "urn" : "urn:rts:audio:13",
          "title" : "L'épouse de Meng Hongweim, ex-patron chinois d'Interpol, craint pour sa sécurité",

--- a/src/test/resources/episode-compositision-radio.json
+++ b/src/test/resources/episode-compositision-radio.json
@@ -1,0 +1,276 @@
+{
+   "show" : {
+      "id" : "1234",
+      "vendor" : "RTS",
+      "transmission" : "RADIO",
+      "urn" : "urn:rts:show:radio:1234",
+      "title" : "Tout un monde",
+      "lead" : "Chaque matin, Eric Guevara-Frey et Patrick Chaboudez mettent la priorité sur l’actualité internationale avec les meilleurs experts, des acteurs internationaux, des reportages et des débats.",
+      "description" : "L'actualité internationale ne s'arrête jamais. Les tensions sont à nouveau vives, autour de la planète et la Suisse est souvent associée dans divers rôles aux principales thématiques internationales.  Pour comprendre ces enjeux, Eric Guevara-Frey et Patrick Chaboudez mettent la priorité sur l'actualité du monde avec les meilleurs experts, des acteurs internationaux, des reportages et des débats.",
+      "imageUrl" : "https://www.rts.ch/2016/06/10/08/29/7677657.image/16x9",
+      "imageTitle" : "Tout un monde [RTS]",
+      "homepageUrl" : "https://details.rts.ch/la-1ere/programmes/tout-un-monde/",
+      "podcastSubscriptionUrl" : "https://www.rts.ch/la-1ere/programmes/tout-un-monde/podcast/",
+      "primaryChannelId" : "a9e7621504c6959e35c3ecbe7f6bed0446cdf8da"
+   },
+   "episodeList" : [ {
+      "id" : "10166113",
+      "title" : "Tout un monde du 01.02.2019",
+      "publishedDate" : "2019-02-01T08:12:26+01:00",
+      "imageUrl" : "https://www.rts.ch/2017/03/03/18/06/8433653.image/16x9",
+      "imageTitle" : "Tout un monde [RTS]",
+      "fullLengthUrn" : "urn:rts:audio:4",
+      "socialCount" : {
+         "key" : "srgView",
+         "value" : 301
+      },
+      "mediaList" : [ {
+         "id" : "4",
+         "mediaType" : "AUDIO",
+         "vendor" : "RTS",
+         "urn" : "urn:rts:audio:4",
+         "title" : "Tout un monde - Présenté par Eric Guevara-Frey",
+         "description" : "Au sommaire: le mouvement antivaccin parmi les dix grandes menaces selon l’OMS; le point sur l’impact des sanctions en Iran; et le zoo jordanien qui recueille les animaux blessés de guerre.",
+         "imageUrl" : "https://www.rts.ch/2017/03/03/18/06/8433653.image/16x9",
+         "imageTitle" : "Tout un monde [RTS]",
+         "type" : "EPISODE",
+         "date" : "2019-02-01T08:12:26+01:00",
+         "duration" : 1424000,
+         "playableAbroad" : true,
+         "presentation" : "DEFAULT"
+      }, {
+         "id" : "41",
+         "mediaType" : "AUDIO",
+         "vendor" : "RTS",
+         "urn" : "urn:rts:audio:41",
+         "title" : "Le mouvement antivaccin parmi les dix grandes menaces selon l’OMS",
+         "imageUrl" : "https://www.rts.ch/2017/12/21/12/15/9193424.image/16x9",
+         "imageTitle" : "La fronde anti-vaccination a-t-elle toujours existé? [Ursule - Fotolia]",
+         "type" : "CLIP",
+         "date" : "2019-02-01T08:12:00+01:00",
+         "duration" : 560000,
+         "playableAbroad" : true,
+         "presentation" : "DEFAULT"
+      }, {
+         "id" : "42",
+         "mediaType" : "AUDIO",
+         "vendor" : "RTS",
+         "urn" : "urn:rts:audio:42",
+         "title" : "Le point sur l’impact des sanctions en Iran",
+         "imageUrl" : "https://www.rts.ch/2018/11/14/16/56/9995060.image/16x9",
+         "imageTitle" : "Une raffinerie de pétrole à Téhéran. (Image d'illustration). [Vahid Salemi - AP]",
+         "type" : "CLIP",
+         "date" : "2019-02-01T08:17:00+01:00",
+         "duration" : 448000,
+         "playableAbroad" : true,
+         "presentation" : "DEFAULT"
+      }, {
+         "id" : "43",
+         "mediaType" : "AUDIO",
+         "vendor" : "RTS",
+         "urn" : "urn:rts:audio:43",
+         "title" : "Le zoo jordanien qui recueille les animaux blessés de guerre",
+         "imageUrl" : "https://www.rts.ch/2019/02/01/16/46/10186367.image/16x9",
+         "imageTitle" : "Un tigre pensionnaire du centre Al Ma'wa en Jordanie, qui recueille des animaux rescapés de zones de guerre. [Rami Elakhras - DR]",
+         "type" : "CLIP",
+         "date" : "2019-02-01T08:22:00+01:00",
+         "duration" : 265000,
+         "playableAbroad" : true,
+         "presentation" : "DEFAULT"
+      } ]
+   }, {
+      "id" : "10163334",
+      "title" : "Tout un monde du 31.01.2019",
+      "publishedDate" : "2019-01-31T08:12:09+01:00",
+      "imageUrl" : "https://www.rts.ch/2016/06/10/08/29/7677657.image/16x9",
+      "imageTitle" : "Tout un monde [RTS]",
+      "fullLengthUrn" : "urn:rts:audio:3",
+      "socialCount" : {
+         "key" : "srgView",
+         "value" : 305
+      },
+      "mediaList" : [ {
+         "id" : "3",
+         "mediaType" : "AUDIO",
+         "vendor" : "RTS",
+         "urn" : "urn:rts:audio:3",
+         "title" : "Tout un monde - Présenté par Eric Guevara-Frey",
+         "imageUrl" : "https://www.rts.ch/2016/06/10/08/29/7677657.image/16x9",
+         "imageTitle" : "Tout un monde [RTS]",
+         "type" : "EPISODE",
+         "date" : "2019-01-31T08:12:09+01:00",
+         "duration" : 1412000,
+         "playableAbroad" : true,
+         "presentation" : "DEFAULT"
+      }, {
+         "id" : "31",
+         "mediaType" : "AUDIO",
+         "vendor" : "RTS",
+         "urn" : "urn:rts:audio:31",
+         "title" : "Les réformes à Shenzhen à l’origine du développement économique de toute la Chine",
+         "imageUrl" : "https://www.rts.ch/2018/12/07/16/10/10052379.image/16x9",
+         "imageTitle" : "En 2019, tous les taxis de Shenzeng rouleront à l'énergie électrique. [RTS]",
+         "type" : "CLIP",
+         "date" : "2019-01-31T08:12:00+01:00",
+         "duration" : 315000,
+         "playableAbroad" : true,
+         "presentation" : "DEFAULT"
+      }, {
+         "id" : "32",
+         "mediaType" : "AUDIO",
+         "vendor" : "RTS",
+         "urn" : "urn:rts:audio:32",
+         "title" : "L’OCDE annonce une campagne pour repenser la fiscalité face à la digitalisation des entreprises",
+         "imageUrl" : "https://www.rts.ch/2019/01/31/09/39/9822376.image/16x9",
+         "imageTitle" : "Le siège de l'OCDE, à Paris. [Charles Platiau - Reuters]",
+         "type" : "CLIP",
+         "date" : "2019-01-31T08:17:00+01:00",
+         "duration" : 628000,
+         "playableAbroad" : true,
+         "presentation" : "DEFAULT"
+      }, {
+         "id" : "33",
+         "mediaType" : "AUDIO",
+         "vendor" : "RTS",
+         "urn" : "urn:rts:audio:33",
+         "title" : "Reportage, le long de la frontière entre les Etats-Unis et le Mexique (2/2)",
+         "imageUrl" : "https://www.rts.ch/2019/01/31/10/57/10182319.image/16x9",
+         "imageTitle" : "Les migrants bloqués du côté mexicain de la frontière dans une situation précaire. [Eric Gay - Keystone/AP]",
+         "type" : "CLIP",
+         "date" : "2019-01-31T08:22:00+01:00",
+         "duration" : 376000,
+         "playableAbroad" : true,
+         "presentation" : "DEFAULT"
+      } ]
+   }, {
+      "id" : "10160597",
+      "title" : "Tout un monde du 30.01.2019",
+      "publishedDate" : "2019-01-30T08:11:53+01:00",
+      "imageUrl" : "https://www.rts.ch/2016/06/10/08/29/7677657.image/16x9",
+      "imageTitle" : "Tout un monde [RTS]",
+      "fullLengthUrn" : "urn:rts:audio:2",
+      "socialCount" : {
+         "key" : "srgView",
+         "value" : 448
+      },
+      "mediaList" : [ {
+         "id" : "2",
+         "mediaType" : "AUDIO",
+         "vendor" : "RTS",
+         "urn" : "urn:rts:audio:2",
+         "title" : "Tout un monde - Présenté par Eric Guevara-Frey",
+         "imageUrl" : "https://www.rts.ch/2016/06/10/08/29/7677657.image/16x9",
+         "imageTitle" : "Tout un monde [RTS]",
+         "type" : "EPISODE",
+         "date" : "2019-01-30T08:11:53+01:00",
+         "duration" : 1448000,
+         "playableAbroad" : true,
+         "presentation" : "DEFAULT"
+      }, {
+         "id" : "21",
+         "mediaType" : "AUDIO",
+         "vendor" : "RTS",
+         "urn" : "urn:rts:audio:21",
+         "title" : "La presse britannique mitigée sur la renégociation annoncée du Brexit",
+         "imageUrl" : "https://www.rts.ch/2019/01/30/06/59/10179357.image/16x9",
+         "imageTitle" : "Theresa May a obtenu un mandat pour renégocier l'accord sur le Brexit. [Mark Duffy - UK Parliament via AP/Keystone]",
+         "type" : "CLIP",
+         "date" : "2019-01-30T08:12:00+01:00",
+         "duration" : 171000,
+         "playableAbroad" : true,
+         "presentation" : "DEFAULT"
+      }, {
+         "id" : "22",
+         "mediaType" : "AUDIO",
+         "vendor" : "RTS",
+         "urn" : "urn:rts:audio:22",
+         "title" : "La crainte de la démocratie en Algérie",
+         "imageUrl" : "https://www.rts.ch/2019/01/29/18/23/8429776.image/16x9",
+         "imageTitle" : "L'actuel président algérien Abdelaziz Bouteflika. [Sidali Djarboub - AP/Keystone]",
+         "type" : "CLIP",
+         "date" : "2019-01-30T08:17:00+01:00",
+         "duration" : 366000,
+         "playableAbroad" : true,
+         "presentation" : "DEFAULT"
+      }, {
+         "id" : "23",
+         "mediaType" : "AUDIO",
+         "vendor" : "RTS",
+         "urn" : "urn:rts:audio:23",
+         "title" : "Reportage le long de la frontière entre les Etats-Unis et le Mexique (1/2)",
+         "imageUrl" : "https://www.rts.ch/2019/01/28/09/02/10172783.image/16x9",
+         "imageTitle" : "La frontière à Brownsville (Texas). [Raphaël Grand - RTS]",
+         "type" : "CLIP",
+         "date" : "2019-01-30T08:22:00+01:00",
+         "duration" : 435000,
+         "playableAbroad" : true,
+         "presentation" : "DEFAULT"
+      }
+      ]
+   }, {
+      "id" : "10157671",
+      "title" : "Tout un monde du 29.01.2019",
+      "publishedDate" : "2019-01-29T08:12:41+01:00",
+      "imageUrl" : "https://www.rts.ch/2016/06/10/08/29/7677657.image/16x9",
+      "imageTitle" : "Tout un monde [RTS]",
+      "fullLengthUrn" : "urn:rts:audio:1",
+      "socialCount" : {
+         "key" : "srgView",
+         "value" : 366
+      },
+      "mediaList" : [ {
+         "id" : "1",
+         "mediaType" : "AUDIO",
+         "vendor" : "RTS",
+         "urn" : "urn:rts:audio:1",
+         "title" : "Tout un monde - Présenté par Eric Guevara-Frey",
+         "imageUrl" : "https://www.rts.ch/2016/06/10/08/29/7677657.image/16x9",
+         "imageTitle" : "Tout un monde [RTS]",
+         "type" : "EPISODE",
+         "date" : "2019-01-29T08:12:41+01:00",
+         "duration" : 1380000,
+         "playableAbroad" : true,
+         "presentation" : "DEFAULT"
+      }, {
+         "id" : "11",
+         "mediaType" : "AUDIO",
+         "vendor" : "RTS",
+         "urn" : "urn:rts:audio:11",
+         "title" : "Le soutien à Theresa May dans sa circonscription d'origine, Maidenhead",
+         "imageUrl" : "https://www.rts.ch/2018/12/17/17/51/10077119.image/16x9",
+         "imageTitle" : "La Première ministre britannique, Theresa May, ne veut pas d'un nouveau référendum sur le Brexit. [epa/Will Oliver - Keystone]",
+         "type" : "CLIP",
+         "date" : "2019-01-29T08:12:00+01:00",
+         "duration" : 251000,
+         "playableAbroad" : true,
+         "presentation" : "DEFAULT"
+      }, {
+         "id" : "12",
+         "mediaType" : "AUDIO",
+         "vendor" : "RTS",
+         "urn" : "urn:rts:audio:12",
+         "title" : "Richard Quest, journaliste de CNN, tire le bilan du Forum économique de Davos",
+         "imageUrl" : "https://www.rts.ch/2019/01/28/18/49/9289640.image/16x9",
+         "imageTitle" : "Retour sur le WEF 2019 avec le journaliste économique américain Richard Quest. [CNN International]",
+         "type" : "CLIP",
+         "date" : "2019-01-29T08:17:00+01:00",
+         "duration" : 612000,
+         "playableAbroad" : true,
+         "presentation" : "DEFAULT"
+      }, {
+         "id" : "13",
+         "mediaType" : "AUDIO",
+         "vendor" : "RTS",
+         "urn" : "urn:rts:audio:13",
+         "title" : "L'épouse de Meng Hongweim, ex-patron chinois d'Interpol, craint pour sa sécurité",
+         "imageUrl" : "https://www.rts.ch/2019/01/18/16/28/10150042.image/16x9",
+         "imageTitle" : "Grace Meng (de dos) lors d'un entretien avec des journalistes en octobre 2018. [Jeff Pachoud - AFP]",
+         "type" : "CLIP",
+         "date" : "2019-01-29T08:22:00+01:00",
+         "duration" : 445000,
+         "playableAbroad" : true,
+         "presentation" : "DEFAULT"
+      } ]
+   }
+  ]
+}

--- a/src/test/resources/urn-rts-audio-0.json
+++ b/src/test/resources/urn-rts-audio-0.json
@@ -1,0 +1,29 @@
+{
+   "id" : "0",
+   "mediaType" : "AUDIO",
+   "vendor" : "RTS",
+   "urn" : "urn:rts:audio:0",
+   "title" : "Tout un monde - Présenté par Eric Guevara-Frey",
+   "imageUrl" : "https://www.rts.ch/2017/03/03/18/06/8433653.image/16x9",
+   "imageTitle" : "Tout un monde [RTS]",
+   "type" : "EPISODE",
+   "date" : "2019-01-28T08:11:19+01:00",
+   "duration" : 1490000,
+   "playableAbroad" : true,
+   "episode" : {
+      "id" : "10154154",
+      "title" : "Tout un monde du 28.01.2019",
+      "imageUrl" : "https://www.rts.ch/2017/03/03/18/06/8433653.image/16x9"
+   },
+   "show" : {
+      "id" : "1234",
+      "vendor" : "RTS",
+      "transmission" : "RADIO",
+      "urn" : "urn:rts:show:radio:1234",
+      "title" : "Tout un monde",
+      "imageUrl" : "http://ws.srf.ch/asset/image/audio/8b32fd87-459e-40f1-9519-ba0cbb01f34e/NOT_SPECIFIED.jpg",
+      "podcastSubscriptionUrl" : "https://www.rts.ch/la-1ere/programmes/tout-un-monde/podcast/",
+      "primaryChannelId" : "a9e7621504c6959e35c3ecbe7f6bed0446cdf8da"
+   },
+   "presentation" : "DEFAULT"
+}

--- a/src/test/resources/urn-rts-audio-01.json
+++ b/src/test/resources/urn-rts-audio-01.json
@@ -1,0 +1,30 @@
+{
+   "id" : "01",
+   "mediaType" : "AUDIO",
+   "vendor" : "RTS",
+   "urn" : "urn:rts:audio:01",
+   "title" : "Huawei soupçonné d'espionnage: interview de Kavé Salamatian, spécialiste de sécurité de réseaux",
+   "description" : "Le fabricant chinois Huawei n’est plus le bienvenu dans plusieurs pays pour y construire des infrastructures de télécommunications. La Suisse commence aussi à se poser des questions. Interview de Kavé Salamatian, spécialiste de sécurité de réseaux, professeur invité à l’Académie des sciences de Chine.",
+   "imageUrl" : "https://www.rts.ch/2019/01/28/09/30/10172835.image/16x9",
+   "imageTitle" : "Huawei. [Huawei est une entreprise privée et elle est partenaire de Swisscom et Sunrise notamment. - AP Chinatopix/Keystone]",
+   "type" : "CLIP",
+   "date" : "2019-01-28T08:12:00+01:00",
+   "duration" : 404000,
+   "playableAbroad" : true,
+   "episode" : {
+      "id" : "10154154",
+      "title" : "Tout un monde du 28.01.2019",
+      "imageUrl" : "https://www.rts.ch/2019/01/28/09/30/10172835.image/16x9"
+   },
+   "show" : {
+      "id" : "1234",
+      "vendor" : "RTS",
+      "transmission" : "RADIO",
+      "urn" : "urn:rts:show:radio:1234",
+      "title" : "Tout un monde",
+      "imageUrl" : "http://ws.srf.ch/asset/image/audio/8b32fd87-459e-40f1-9519-ba0cbb01f34e/NOT_SPECIFIED.jpg",
+      "podcastSubscriptionUrl" : "https://www.rts.ch/la-1ere/programmes/tout-un-monde/podcast/",
+      "primaryChannelId" : "a9e7621504c6959e35c3ecbe7f6bed0446cdf8da"
+   },
+   "presentation" : "DEFAULT"
+}

--- a/src/test/resources/urn-rts-audio-1.json
+++ b/src/test/resources/urn-rts-audio-1.json
@@ -1,0 +1,29 @@
+{
+   "id" : "1",
+   "mediaType" : "AUDIO",
+   "vendor" : "RTS",
+   "urn" : "urn:rts:audio:1",
+   "title" : "Tout un monde - Présenté par Eric Guevara-Frey",
+   "imageUrl" : "https://www.rts.ch/2016/06/10/08/29/7677657.image/16x9",
+   "imageTitle" : "Tout un monde [RTS]",
+   "type" : "EPISODE",
+   "date" : "2019-01-29T08:12:41+01:00",
+   "duration" : 1380000,
+   "playableAbroad" : true,
+   "episode" : {
+      "id" : "10157671",
+      "title" : "Tout un monde du 29.01.2019",
+      "imageUrl" : "https://www.rts.ch/2016/06/10/08/29/7677657.image/16x9"
+   },
+   "show" : {
+      "id" : "1234",
+      "vendor" : "RTS",
+      "transmission" : "RADIO",
+      "urn" : "urn:rts:show:radio:1234",
+      "title" : "Tout un monde",
+      "imageUrl" : "http://ws.srf.ch/asset/image/audio/8b32fd87-459e-40f1-9519-ba0cbb01f34e/NOT_SPECIFIED.jpg",
+      "podcastSubscriptionUrl" : "https://www.rts.ch/la-1ere/programmes/tout-un-monde/podcast/",
+      "primaryChannelId" : "a9e7621504c6959e35c3ecbe7f6bed0446cdf8da"
+   },
+   "presentation" : "DEFAULT"
+}

--- a/src/test/resources/urn-rts-audio-11.json
+++ b/src/test/resources/urn-rts-audio-11.json
@@ -1,0 +1,29 @@
+{
+   "id" : "11",
+   "mediaType" : "AUDIO",
+   "vendor" : "RTS",
+   "urn" : "urn:rts:audio:11",
+   "title" : "Le soutien à Theresa May dans sa circonscription d'origine, Maidenhead",
+   "imageUrl" : "https://www.rts.ch/2018/12/17/17/51/10077119.image/16x9",
+   "imageTitle" : "La Première ministre britannique, Theresa May, ne veut pas d'un nouveau référendum sur le Brexit. [epa/Will Oliver - Keystone]",
+   "type" : "CLIP",
+   "date" : "2019-01-29T08:12:00+01:00",
+   "duration" : 251000,
+   "playableAbroad" : true,
+   "episode" : {
+      "id" : "10157671",
+      "title" : "Tout un monde du 29.01.2019",
+      "imageUrl" : "https://www.rts.ch/2018/12/17/17/51/10077119.image/16x9"
+   },
+   "show" : {
+      "id" : "1234",
+      "vendor" : "RTS",
+      "transmission" : "RADIO",
+      "urn" : "urn:rts:show:radio:1234",
+      "title" : "Tout un monde",
+      "imageUrl" : "http://ws.srf.ch/asset/image/audio/8b32fd87-459e-40f1-9519-ba0cbb01f34e/NOT_SPECIFIED.jpg",
+      "podcastSubscriptionUrl" : "https://www.rts.ch/la-1ere/programmes/tout-un-monde/podcast/",
+      "primaryChannelId" : "a9e7621504c6959e35c3ecbe7f6bed0446cdf8da"
+   },
+   "presentation" : "DEFAULT"
+}

--- a/src/test/resources/urn-rts-audio-2.json
+++ b/src/test/resources/urn-rts-audio-2.json
@@ -1,0 +1,29 @@
+{
+   "id" : "2",
+   "mediaType" : "AUDIO",
+   "vendor" : "RTS",
+   "urn" : "urn:rts:audio:2",
+   "title" : "Tout un monde - Présenté par Eric Guevara-Frey",
+   "imageUrl" : "https://www.rts.ch/2016/06/10/08/29/7677657.image/16x9",
+   "imageTitle" : "Tout un monde [RTS]",
+   "type" : "EPISODE",
+   "date" : "2019-01-30T08:11:53+01:00",
+   "duration" : 1448000,
+   "playableAbroad" : true,
+   "episode" : {
+      "id" : "10160597",
+      "title" : "Tout un monde du 30.01.2019",
+      "imageUrl" : "https://www.rts.ch/2016/06/10/08/29/7677657.image/16x9"
+   },
+   "show" : {
+      "id" : "1234",
+      "vendor" : "RTS",
+      "transmission" : "RADIO",
+      "urn" : "urn:rts:show:radio:1234",
+      "title" : "Tout un monde",
+      "imageUrl" : "http://ws.srf.ch/asset/image/audio/8b32fd87-459e-40f1-9519-ba0cbb01f34e/NOT_SPECIFIED.jpg",
+      "podcastSubscriptionUrl" : "https://www.rts.ch/la-1ere/programmes/tout-un-monde/podcast/",
+      "primaryChannelId" : "a9e7621504c6959e35c3ecbe7f6bed0446cdf8da"
+   },
+   "presentation" : "DEFAULT"
+}

--- a/src/test/resources/urn-rts-audio-3.json
+++ b/src/test/resources/urn-rts-audio-3.json
@@ -1,0 +1,29 @@
+{
+   "id" : "3",
+   "mediaType" : "AUDIO",
+   "vendor" : "RTS",
+   "urn" : "urn:rts:audio:3",
+   "title" : "Tout un monde - Présenté par Eric Guevara-Frey",
+   "imageUrl" : "https://www.rts.ch/2016/06/10/08/29/7677657.image/16x9",
+   "imageTitle" : "Tout un monde [RTS]",
+   "type" : "EPISODE",
+   "date" : "2019-01-31T08:12:09+01:00",
+   "duration" : 1412000,
+   "playableAbroad" : true,
+   "episode" : {
+      "id" : "10163334",
+      "title" : "Tout un monde du 31.01.2019",
+      "imageUrl" : "https://www.rts.ch/2016/06/10/08/29/7677657.image/16x9"
+   },
+   "show" : {
+      "id" : "1234",
+      "vendor" : "RTS",
+      "transmission" : "RADIO",
+      "urn" : "urn:rts:show:radio:1234",
+      "title" : "Tout un monde",
+      "imageUrl" : "http://ws.srf.ch/asset/image/audio/8b32fd87-459e-40f1-9519-ba0cbb01f34e/NOT_SPECIFIED.jpg",
+      "podcastSubscriptionUrl" : "https://www.rts.ch/la-1ere/programmes/tout-un-monde/podcast/",
+      "primaryChannelId" : "a9e7621504c6959e35c3ecbe7f6bed0446cdf8da"
+   },
+   "presentation" : "DEFAULT"
+}

--- a/src/test/resources/urn-rts-audio-31.json
+++ b/src/test/resources/urn-rts-audio-31.json
@@ -1,0 +1,29 @@
+{
+   "id" : "31",
+   "mediaType" : "AUDIO",
+   "vendor" : "RTS",
+   "urn" : "urn:rts:audio:31",
+   "title" : "Les réformes à Shenzhen à l’origine du développement économique de toute la Chine",
+   "imageUrl" : "https://www.rts.ch/2018/12/07/16/10/10052379.image/16x9",
+   "imageTitle" : "En 2019, tous les taxis de Shenzeng rouleront à l'énergie électrique. [RTS]",
+   "type" : "CLIP",
+   "date" : "2019-01-31T08:12:00+01:00",
+   "duration" : 315000,
+   "playableAbroad" : true,
+   "episode" : {
+      "id" : "10163334",
+      "title" : "Tout un monde du 31.01.2019",
+      "imageUrl" : "https://www.rts.ch/2018/12/07/16/10/10052379.image/16x9"
+   },
+   "show" : {
+      "id" : "1234",
+      "vendor" : "RTS",
+      "transmission" : "RADIO",
+      "urn" : "urn:rts:show:radio:1234",
+      "title" : "Tout un monde",
+      "imageUrl" : "http://ws.srf.ch/asset/image/audio/8b32fd87-459e-40f1-9519-ba0cbb01f34e/NOT_SPECIFIED.jpg",
+      "podcastSubscriptionUrl" : "https://www.rts.ch/la-1ere/programmes/tout-un-monde/podcast/",
+      "primaryChannelId" : "a9e7621504c6959e35c3ecbe7f6bed0446cdf8da"
+   },
+   "presentation" : "DEFAULT"
+}

--- a/src/test/resources/urn-rts-audio-4.json
+++ b/src/test/resources/urn-rts-audio-4.json
@@ -1,0 +1,30 @@
+{
+   "id" : "4",
+   "mediaType" : "AUDIO",
+   "vendor" : "RTS",
+   "urn" : "urn:rts:audio:4",
+   "title" : "Tout un monde - Présenté par Eric Guevara-Frey",
+   "description" : "Au sommaire: le mouvement antivaccin parmi les dix grandes menaces selon l’OMS; le point sur l’impact des sanctions en Iran; et le zoo jordanien qui recueille les animaux blessés de guerre.",
+   "imageUrl" : "https://www.rts.ch/2017/03/03/18/06/8433653.image/16x9",
+   "imageTitle" : "Tout un monde [RTS]",
+   "type" : "EPISODE",
+   "date" : "2019-02-01T08:12:26+01:00",
+   "duration" : 1424000,
+   "playableAbroad" : true,
+   "episode" : {
+      "id" : "10166113",
+      "title" : "Tout un monde du 01.02.2019",
+      "imageUrl" : "https://www.rts.ch/2017/03/03/18/06/8433653.image/16x9"
+   },
+   "show" : {
+      "id" : "1234",
+      "vendor" : "RTS",
+      "transmission" : "RADIO",
+      "urn" : "urn:rts:show:radio:1234",
+      "title" : "Tout un monde",
+      "imageUrl" : "http://ws.srf.ch/asset/image/audio/8b32fd87-459e-40f1-9519-ba0cbb01f34e/NOT_SPECIFIED.jpg",
+      "podcastSubscriptionUrl" : "https://www.rts.ch/la-1ere/programmes/tout-un-monde/podcast/",
+      "primaryChannelId" : "a9e7621504c6959e35c3ecbe7f6bed0446cdf8da"
+   },
+   "presentation" : "DEFAULT"
+}

--- a/src/test/resources/urn-rts-audio-42.json
+++ b/src/test/resources/urn-rts-audio-42.json
@@ -1,0 +1,29 @@
+{
+   "id" : "42",
+   "mediaType" : "AUDIO",
+   "vendor" : "RTS",
+   "urn" : "urn:rts:audio:42",
+   "title" : "Le point sur l’impact des sanctions en Iran",
+   "imageUrl" : "https://www.rts.ch/2018/11/14/16/56/9995060.image/16x9",
+   "imageTitle" : "Une raffinerie de pétrole à Téhéran. (Image d'illustration). [Vahid Salemi - AP]",
+   "type" : "CLIP",
+   "date" : "2019-02-01T08:17:00+01:00",
+   "duration" : 448000,
+   "playableAbroad" : true,
+   "episode" : {
+      "id" : "10166113",
+      "title" : "Tout un monde du 01.02.2019",
+      "imageUrl" : "https://www.rts.ch/2018/11/14/16/56/9995060.image/16x9"
+   },
+   "show" : {
+      "id" : "1234",
+      "vendor" : "RTS",
+      "transmission" : "RADIO",
+      "urn" : "urn:rts:show:radio:1234",
+      "title" : "Tout un monde",
+      "imageUrl" : "http://ws.srf.ch/asset/image/audio/8b32fd87-459e-40f1-9519-ba0cbb01f34e/NOT_SPECIFIED.jpg",
+      "podcastSubscriptionUrl" : "https://www.rts.ch/la-1ere/programmes/tout-un-monde/podcast/",
+      "primaryChannelId" : "a9e7621504c6959e35c3ecbe7f6bed0446cdf8da"
+   },
+   "presentation" : "DEFAULT"
+}


### PR DESCRIPTION
When asking for a media recommendation list for an RTS audio, next episodes or clips are provided.
Then, old episodes or clips and recommended.

More details in `docs/RECOMMENDATION.md`. Based on discussions afters @svenduvoisin tests.

@SebastienChauvin Please add in this file the first Play Android version supporting `Playfff` recommendations.

This pull request also fixes the recommended page size for peach requests (49, not 50).