### PR TITLE
Switch RTS recommendation to playfff reco engine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>ch.srgssr</groupId>
     <artifactId>playfff</artifactId>
-    <version>27</version>
+    <version>28</version>
     <packaging>jar</packaging>
 
     <name>pfff</name>

--- a/src/main/java/ch/srgssr/playfff/service/RecommendationService.java
+++ b/src/main/java/ch/srgssr/playfff/service/RecommendationService.java
@@ -37,15 +37,9 @@ public class RecommendationService {
         IlUrn urn = new IlUrn(urnString);
         if (purpose.equals("relatedContent")) {
             switch (urn.getMam()) {
-                case RTS:
-                    if (urn.getMediaType() == MediaType.VIDEO) {
-                        return rtsVideoRecommendedList(purpose, urnString, standalone);
-                    } else if (urn.getMediaType() == MediaType.AUDIO) {
-                        return pfffRecommendedList(urnString, MediaType.AUDIO, standalone);
-                    }
-                    break;
                 case SRF:
                     return srfRecommendedList(purpose, urnString, standalone);
+                case RTS:
                 case RSI:
                 case RTR:
                 case SWI:


### PR DESCRIPTION
RTS recommendation currently has an issue for TV shows, so we fallback to the simple Playfff recommendation.